### PR TITLE
Gruppenoptionen Codeliste geleert - Issue #136 

### DIFF
--- a/docs/codelisten.md
+++ b/docs/codelisten.md
@@ -135,10 +135,11 @@ eA | erhöhtes Anforderungsniveau
 
 ## Gruppenoption
 
+ Hinweis: In der aktuellen Version sind noch keine Werte vorhanden.  
+ Hinweis: Diese Codeliste ist nicht länderübergreifend und potentiell von Bundesland zu Bundesland abweichend.
+
 Code | Bezeichnung
 --- | ---
-01 | bilingual
-02 | herkunftssprachlich
 
 ## Gruppentyp
 

--- a/docs/datenmodell/gruppendatensatz.md
+++ b/docs/datenmodell/gruppendatensatz.md
@@ -22,7 +22,7 @@ gruppenzugehoerigkeiten | Gruppenzugehörigkeit | 0..n  | Liste (Array) von Grup
     "typ": "Kurs",
     "bereich": "Pflicht",
     "optionen": [
-      "01"
+      ""
     ],
     "differenzierung": "E",
     "bildungsziele": [

--- a/docs/english-api-notes/code-lists.md
+++ b/docs/english-api-notes/code-lists.md
@@ -28,7 +28,7 @@ Trägerschaft | The „ownership” of an organisation. Describes whether it is 
 Lokalisierung | Provides localisation information. Usually „de-DE“ to denote German language content.
 Gruppenbereich | Denotes whether participation in a group is optional („Wahl”), mandatory („Pflicht”) or a combination of both for its members.
 Gruppendifferenzierung | An attribute to specify a specific level of a course. Conceptually similar to denoting courses in the UK education system as „A-Level” or „O-Level“ courses.
-Gruppenoption | Currently there are only two options available, one being „bilingual” and the other „taught in (students’s) native language”.
+Gruppenoption | Currently there are no options implemented.
 Gruppentyp | Classification of a group as „class”, „course“ or „other”. Classes are generally mandatory, while courses are often optional.
 Gruppenrolle | Similar to „Rolle”, but as this refers to roles in a group and not in an organisation, the options differ slightly. For example, groups cannot have system administrator, while organisations don't have group leaders.
 Lernperiode | A teaching period, usually a year or a semester (trimesters are rare in Germany). A more specific description of the structure of codes from this list is given in 13.1.9 Lernperiode.

--- a/static/openapi/components-code-Gruppenoption.yaml
+++ b/static/openapi/components-code-Gruppenoption.yaml
@@ -1,8 +1,6 @@
 type: string
 enum:
-  - "01"
-  - "02"
+  - ""
 description: >
-    Wie folgt:
-      * 01 bilingual
-      * 02 herkunftssprachlich
+    Hinweis: In der aktuellen Version sind noch keine Werte vorhanden.
+    Hinweis: Diese Codeliste ist nicht länderübergreifend und potentiell von Bundesland zu Bundesland abweichend.

--- a/static/openapi/paths-person-info.yaml
+++ b/static/openapi/paths-person-info.yaml
@@ -140,7 +140,7 @@ get:
                 "typ": "Kurs",
                 "bereich": "Pflicht",
                 "optionen": [
-                  "01"
+                  ""
                 ],
                 "differenzierung": "E",
                 "bildungsziele": [


### PR DESCRIPTION
Alle Werte aus der Codeliste entfernt, Hinweis hinzugefügt, dass Liste nicht länderübergreifend ist. YAML möchte bei 'Enum' gerne mindestens eine Option, daher dort als 'Wert' den leeren String eingefügt (""). Nicht elegant, aber die Alternative wäre es "Gruppenoption" aus v1.5 vollständig zu entfernen.

 Codeliste Gruppenoptionen leeren (TFS #5901) #136 
