### PR TITLE
Erweiterter Hinweis zur Codeliste Fächerkanon

### DIFF
--- a/docs/codelisten.md
+++ b/docs/codelisten.md
@@ -198,7 +198,6 @@ Hinweis: Die folgende Codeliste ist spezifisch für das Bundesland Niedersachsen
 Bundesländer nur als Beispiel, da der Fächerkanon abweichen kann. Der lokal gültige Fächerkanon
 ist beim jeweiligen Betreiber des Schulconnex-Servers nachzufragen.
 
-
 Code | Bezeichnung
 --- | ---
 BI | Biologie


### PR DESCRIPTION
https://github.com/Schulconnex/Schulconnex/issues/135

Besser Erklärung in Beschreibung. Spec Codeliste als Beispiel für NI. Konkrete Codeliste "out of band" vom Schulconnex Betreiber "in Erfahrunung bringen".