### PR TITLE
188 filter vollstaendig für personen info besser erläutern

### DIFF
--- a/src/openapi/paths-personen-info.yaml
+++ b/src/openapi/paths-personen-info.yaml
@@ -37,6 +37,13 @@ get:
     `gruppen` oder `beziehungen` annehmen. Mehrere Werte können, getrennt durch Kommas, in einem
     Filter genutzt werden.
 
+    Zu beachten ist hierbei, dass bei Objekt-Hierarchien untergeordnete Objekte nur dann
+    ausgegeben werden, wenn auch die in der Hierarchie direkt darüber liegenden Objekte ausgegeben
+    werden. So werden bei der Auswahl von `vollstaendig=personen,organisationen` Informationen
+    zu den Organisationen nicht mit ausgegeben, da diese nicht Teil von `personen` sind, sondern
+    von `personenkontexten`. Sollen Informationen zu Organisationen mit ausgegeben werden, so
+    ist als Filter `vollstaendig=personen,personenkontexte,organisationen` zu benutzen.
+
     Darüber hinaus kann auch eine Filterung nach Personen, Personenkontexten, Gruppen und
     Organisationen anhand der jeweiligen ID erfolgen.
 


### PR DESCRIPTION
Explizites Beispiel mit Personen, Personenkontexten und Organisationen basierend auf dem Beispiel im Ticket.