### PR TITLE
Ersetze relative URLs mit schulconnex.de-URL in deref OpenAPI

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "write-heading-ids": "docusaurus write-heading-ids",
     "build-openapi-docs": "npx docusaurus gen-api-docs all",
     "clean-openapi-docs": "git clean -dxf -- docs/generated/",
-    "write-dereferenced-openapi-for-qs": "redocly bundle --dereferenced --remove-unused-components src/openapi/api-qs.yaml -o static/dist/openapi/api-qs.yaml",
-    "write-dereferenced-openapi-for-dienste": "redocly bundle --dereferenced --remove-unused-components src/openapi/api-dienste.yaml -o static/dist/openapi/api-dienste.yaml",
+    "write-dereferenced-openapi-for-qs": "redocly bundle --dereferenced --remove-unused-components src/openapi/api-qs.yaml | node util/resolve-relative-urls.js > static/dist/openapi/api-qs.yaml",
+    "write-dereferenced-openapi-for-dienste": "redocly bundle --dereferenced --remove-unused-components src/openapi/api-dienste.yaml | node util/resolve-relative-urls.js > static/dist/openapi/api-dienste.yaml",
     "write-dereferenced-openapi": "npm run write-dereferenced-openapi-for-dienste && npm run write-dereferenced-openapi-for-qs",
     "validate-openapi": "npx @redocly/cli lint src/openapi/api-dienste.yaml src/openapi/api-qs.yaml"
   },

--- a/static/dist/openapi/.gitignore
+++ b/static/dist/openapi/.gitignore
@@ -1,0 +1,5 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore
+

--- a/util/resolve-relative-urls.js
+++ b/util/resolve-relative-urls.js
@@ -1,0 +1,11 @@
+const fs = require('fs');
+
+const REGEX_RELATIVE_URL = /(\.\.\/)+/g;
+const BASE_URL = 'https://schulconnex.de/docs/';
+
+const out = fs.readFileSync(0, 'utf-8')
+  .split(/\r?\n/)
+  .map(line => line.replace(REGEX_RELATIVE_URL, BASE_URL))
+  .join('\n');
+
+console.log(out);


### PR DESCRIPTION
Testen mit Aufruf von: `npm run write-dereferenced-openapi` und dann schauen wie die Dateien in `static/dist/openapi/` aussehen.

Die URLs funktionieren noch nicht, da 

a) die Weiterleitung für HTTPS noch nicht funktioniert, siehe #263 
b) die Weiterleitung auch für HTTP (ohne S) nicht den auf den entsprechenden Pfad weiterleitet, so dass man immer bei der Homepage ankommt, also https://schulconnex.github.io/Schulconnex/