### PR TITLE
Organisationstyp Behörde (und Schulträger) einführen #294

### DIFF
--- a/docs/codelisten.md
+++ b/docs/codelisten.md
@@ -243,6 +243,8 @@ Code | Bezeichnung
 --- | ---
 Schule | Schule
 Anbieter | Anbieter
+Behoerde | Behörde
+SchTrae | Schulträger
 Sonstige | sonstige Organisationen / Einrichtungen
 
 ## Personenstatus

--- a/src/openapi/components-code-Organisationstyp.yaml
+++ b/src/openapi/components-code-Organisationstyp.yaml
@@ -2,9 +2,13 @@ type: string
 enum:
   - Schule
   - Anbieter
+  - Behoerde
+  - SchTrae
   - Sonstige
 description: >
     Wie folgt:
       * Schule
       * Anbieter
+      * Behörde
+      * Schulträger
       * Sonstige sonstige Organisationen / Einrichtungen


### PR DESCRIPTION
Behörde und Schulträger in der Codelistenbescheibung und OpenAPI hinzugefügt.

Hinweis: Code für Schulträger ist SchTrae, da wir das bereits in Organisationsbeziehungen für Schulträger nutzen.