### PR TITLE
Reflektiere Einigung bzgl Definition von access_control-Objekt

### DIFF
--- a/src/openapi/components-policies-Mediendatensatz.yaml
+++ b/src/openapi/components-policies-Mediendatensatz.yaml
@@ -30,5 +30,7 @@ properties:
         anyOf:
           - $ref: './components-policies-Zugriffsinfo-licenseKey.yaml'
           - $ref: './components-policies-Zugriffsinfo-object.yaml'
-        example:
-          licenseKey: 5f49ff7f-76a6-4d8b-ae40-e1aba0d57f21
+    example:
+      type: license_key
+      value:
+        licenseKey: 5f49ff7f-76a6-4d8b-ae40-e1aba0d57f21

--- a/src/openapi/components-policies-MediendatensatzLD.yaml
+++ b/src/openapi/components-policies-MediendatensatzLD.yaml
@@ -30,3 +30,7 @@ properties:
         anyOf:
           - $ref: './components-policies-Zugriffsinfo-licenseKey.yaml'
           - $ref: './components-policies-Zugriffsinfo-object.yaml'
+    example:
+      type: license_key
+      value:
+        licenseKey: 5f49ff7f-76a6-4d8b-ae40-e1aba0d57f21

--- a/src/openapi/components-policies-Zugriffsinfo-object.yaml
+++ b/src/openapi/components-policies-Zugriffsinfo-object.yaml
@@ -1,3 +1,7 @@
 type: object
+properties:
+  property name*:
+    type: any
+    description: Beliebige Anzahl und Typ von weiteren Properties mit beliebigem Namen
 minProperties: 1
 additionalProperties: true


### PR DESCRIPTION
- beliebige Properties im Falle von custom-Objekten
- generiertes "Example" zeigt Beispiel für type: license_key