### PR TITLE
#347 Sichtfreigabe bei Diensten

### DIFF
--- a/docs/datenmodell-dienste/sichtfreigabe.md
+++ b/docs/datenmodell-dienste/sichtfreigabe.md
@@ -1,7 +1,0 @@
----
-title: ''
----
-
-import Text from '../datenmodell-qs/sichtfreigabe.md';
-
-<Text />

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -136,11 +136,6 @@ const sidebars: SidebarsConfig = {
           id: 'datenmodell-dienste/personenkontext',
           label: 'Personenkontext',
         },
-        {
-          type: 'doc',
-          id: 'datenmodell-dienste/sichtfreigabe',
-          label: 'Sichtfreigabe',
-        },
       ],
     },
     {


### PR DESCRIPTION
Dienste sehen keine Informationen über Sichtfreigaben, daher das Datenmodell as der Liste für Dienste entfernt.