### PR TITLE
#400 ist_von Beziehung aus Personen-info entfernt

### DIFF
--- a/src/openapi/components-dienste-Personen-info-Personendatensatz.yaml
+++ b/src/openapi/components-dienste-Personen-info-Personendatensatz.yaml
@@ -1,0 +1,14 @@
+type: object
+required:
+  - pid
+properties:
+  pid:
+    description: Pseudonymisierte ID. Referenziert ein bestehendes Objekt des Schulconnex-Servers.
+    type: string
+    example: df6588cf8dc649ef79fcc852e1064761442a32bf3496ecd9bde0f66a18685aaa
+  person:
+    $ref: './components-dienste-Person.yaml'
+  personenkontexte:
+    type: array
+    items:
+      $ref: './components-dienste-Personen-info-Personenkontext.yaml'

--- a/src/openapi/components-dienste-Personen-info-Personenkontext.yaml
+++ b/src/openapi/components-dienste-Personen-info-Personenkontext.yaml
@@ -1,0 +1,46 @@
+type: object
+required:
+  - id
+  - organisation
+  - rolle
+properties:
+  id:
+    description: ID des Personenkontexts. Referenziert ein bestehendes Objekt des Schulconnex-Servers.
+    type: string
+    example: 4d0f579c0b9a4d3ab48487b3bee8a2ad4d0f579c0b9a4d3ab48487b3bee8a2ad
+  organisation:
+    allOf:
+      - $ref: './components-Organisation-basis.yaml'
+      - $ref: './components-Organisation.yaml'
+  gruppen:
+    description: ''
+    type: array
+    items:
+      $ref: './components-dienste-Gruppendatensatz.yaml'
+  beziehungen:
+    description: ''
+    type: object
+    properties:
+      hat_als_beziehungen:
+        type: array
+        items:
+          $ref: './components-dienste-Beziehung.yaml'
+  erreichbarkeiten:
+    description: ''
+    type: array
+    items:
+      $ref: './components-Erreichbarkeit.yaml'
+  personenstatus:
+    $ref: './components-code-Personenstatus.yaml'
+  jahrgangsstufe:
+    $ref: './components-code-Jahrgangsstufe.yaml'
+  rolle:
+    $ref: './components-code-Rolle.yaml'
+  loeschung:
+    description: ''
+    type: object
+    properties:
+      zeitpunkt:
+        description: Datum und Uhrzeit der Löschung des Personenkontexts.
+        type: string
+        format: date-time

--- a/src/openapi/components-dienste-Personendatensätze.yaml
+++ b/src/openapi/components-dienste-Personendatensätze.yaml
@@ -1,3 +1,3 @@
 type: array
 items:
-  $ref: './components-dienste-Personendatensatz.yaml'
+  $ref: './components-dienste-Personen-info-Personendatensatz.yaml'


### PR DESCRIPTION
Dieses Commit führt leider zu einer Reihe von kopierten Dateien, da sich personen-info über components-dienste-Personendatensätze.yaml -> components-dienste-Personendatensatz.yaml -> components-dienste-Personenkontext.yaml auf dieselbe Personenkontext-Beschreiobung wie paths-person-info.yaml bezieht.

Da bei person-info auch ist_von Beziehungen geliefert werden können, sind diese bei der Beschreibunt in omponents-dienste-Personendatensatz.yaml auch mit aufgenommen und wurden dann indirekt auch bei personen-info auch referenziert.

Jetzt wurdeb für personen-info eigene Beschreibungen von Personendatensatz und Personenkontext angelegt, so dass hier in Personenkontext die ist_von Beziehung entfernt werden konnte, ohne sie auch bei person-info zu entfernen.