### PR TITLE
#430 Verlinkungen auf https://login.schulconnex.test/

### DIFF
--- a/src/openapi/api-dienste.yaml
+++ b/src/openapi/api-dienste.yaml
@@ -11,7 +11,7 @@ info:
     name: Creative Commons Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)
     url: https://creativecommons.org/licenses/by-nd/4.0/legalcode
 servers:
-  - url: https://schulconnex.test/v1
+  - url: https&zwj;://schulconnex.test/v1
     description: Lokaler Testserver
 security:
   - oAuthForServices: []

--- a/src/openapi/api-policies.yaml
+++ b/src/openapi/api-policies.yaml
@@ -11,7 +11,7 @@ info:
     name: Creative Commons Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)
     url: https://creativecommons.org/licenses/by-nd/4.0/legalcode
 servers:
-  - url: https://schulconnex.test/v1
+  - url: https&zwj;://schulconnex.test/v1
     description: Lokaler Testserver
 security:
   - oAuthForServices: []

--- a/src/openapi/api-qs.yaml
+++ b/src/openapi/api-qs.yaml
@@ -11,7 +11,7 @@ info:
     name: Creative Commons Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)
     url: https://creativecommons.org/licenses/by-nd/4.0/legalcode
 servers:
-  - url: https://schulconnex.test/v1
+  - url: https&zwj;://schulconnex.test/v1
     description: Lokaler Testserver
 security:
   - oAuthForServices: []

--- a/src/openapi/securitySchema-oAuthForServices.yaml
+++ b/src/openapi/securitySchema-oAuthForServices.yaml
@@ -2,6 +2,6 @@ type: oauth2
 description: Die API nutzt den OAuth 2.0 Client Credentials Flow.
 flows:
   clientCredentials:
-    tokenUrl: https://login.schulconnex.test/token
+    tokenUrl: https&zwj;://login.schulconnex.test/token
     scopes:
       none: not available

--- a/src/openapi/securitySchema-oAuthForUser.yaml
+++ b/src/openapi/securitySchema-oAuthForUser.yaml
@@ -1,7 +1,7 @@
 type: oauth2
 flows:
   authorizationCode:
-    authorizationUrl: https://login.schulconnex.test/auth
-    tokenUrl: https://login.schulconnex.test/token
+    authorizationUrl: https&zwj;://login.schulconnex.test/auth
+    tokenUrl: https&zwj;://login.schulconnex.test/token
     scopes:
       person-info: Enthält Vorname, Nachname, Rolle und Organisationskennung


### PR DESCRIPTION
Das Einfügen von &zwj; (Zero Width Joiner) in den Protokollnamen verhindert, dass ein konzeptioneller Link on OpenAPI als klickbarer Link angezeigt wird.