### PR TITLE
#420 “Weiter”-Text auf Seite "Nutzung der REST-API"

### DIFF
--- a/docs/lizenzerweiterung/schnittstellen/schnittstellen.md
+++ b/docs/lizenzerweiterung/schnittstellen/schnittstellen.md
@@ -1,5 +1,5 @@
 ---
-title: ''
+title: 'Nutzung der REST-API'
 tags:
 - Verbindlich
 ---

--- a/docs/schnittstellen/schnittstellen-dienste.md
+++ b/docs/schnittstellen/schnittstellen-dienste.md
@@ -1,5 +1,5 @@
 ---
-title: ''
+title: 'Nutzung der REST-API'
 ---
 
 import Text from './schnittstellen.md';

--- a/docs/schnittstellen/schnittstellen-qs.md
+++ b/docs/schnittstellen/schnittstellen-qs.md
@@ -1,5 +1,5 @@
 ---
-title: ''
+title: 'Nutzung der REST-API'
 ---
 
 import Text from './schnittstellen.md';


### PR DESCRIPTION
Titel jetzt explizit auch im title-Tag angegeben, damit er auch auf den Links auftaucht, welche zu dieser Seite führen.