### PR TITLE
#413 Benennung der Datenmodelle für Dienste ist inkonsistent.

### DIFF
--- a/docs/datenmodell-dienste/gruppe.md
+++ b/docs/datenmodell-dienste/gruppe.md
@@ -2,7 +2,7 @@
 title: Gruppe
 ---
 
-# Datenmodell Gruppe für Diensteanbieter
+# Datenmodell Gruppe für Dienste
 
 Eine Gruppe erlaubt es, mehrere Personen in einer Gruppe zusammenzufassen. Typischerweise handelt es sich
 bei einer Gruppe um eine Schulklasse oder eine ähnliche Struktur in einer Schule oder anderen Organisation.

--- a/docs/datenmodell-dienste/organisation.md
+++ b/docs/datenmodell-dienste/organisation.md
@@ -2,7 +2,7 @@
 title: Organisation
 ---
 
-# Datenmodell Organisation für Diensteanbieter
+# Datenmodell Organisation für Dienste
 
 Personen können einer Organisation angehören, jedoch zeitweise an einer anderen Organisation tätig sein. Die erste
 Organisation ist die Stammorganisation. Der häufigste Anwendungsfall ist die Abordnung einer Lehrerin oder eines Lehrers an eine

--- a/docs/datenmodell-dienste/person.md
+++ b/docs/datenmodell-dienste/person.md
@@ -2,7 +2,7 @@
 title: Person
 ---
 
-# Datenmodell Person für Diensteanbieter
+# Datenmodell Person für Dienste
 
 Nachfolgend ist das Datenmodell einer Person dargestellt.
 

--- a/docs/datenmodell-dienste/personenkontext.md
+++ b/docs/datenmodell-dienste/personenkontext.md
@@ -2,7 +2,7 @@
 title: Personenkontext
 ---
 
-# Datenmodell Personenkontext für Diensteanbieter
+# Datenmodell Personenkontext für Dienste
 
 Hat eine Person mehrere Personenkontexte, so wird typischerweise bereits bei der Anmeldung im
 Sicherheitskontext einer angemeldeten Person einer dieser Kontexte selektiert. In diesem Fall

--- a/docs/schnittstellen/vendor-extensions.md
+++ b/docs/schnittstellen/vendor-extensions.md
@@ -16,7 +16,7 @@ Der Name eines anbieterspezifischen Attributs muss ein gültiger Uniform Resourc
 
 Der Wert eines anbieterspezifischen Attributs kann ein primitiver Typ, ein Array von primitiven Typen, ein komplexes Objekt oder ein Array von Objekten sein. Es besteht nicht die Notwendigkeit, für Attributnamen innerhalb von anbieterspezifischen Objekten URNs zu nutzen.
 
-Betreiber von Schulconnex-Servern, die anbieterspezifische Attribute verwenden, müssen definieren, ob und nach welchen Kriterien solche Attribute auch an Dienste ausgeliefert werden und wie viele Elemente die Antwort enthalten kann oder muss. Hierzu ist das Datenmodell für Diensteanbieter, wo erforderlich, um diese Attribute zu erweitern und, analog zu den standardisierten Attributen, die auszuliefernde Anzahl und die Notwendigkeit einer Freigabe zu spezifizieren.
+Betreiber von Schulconnex-Servern, die anbieterspezifische Attribute verwenden, müssen definieren, ob und nach welchen Kriterien solche Attribute auch an Dienste ausgeliefert werden und wie viele Elemente die Antwort enthalten kann oder muss. Hierzu ist das Datenmodell für Dienste, wo erforderlich, um diese Attribute zu erweitern und, analog zu den standardisierten Attributen, die auszuliefernde Anzahl und die Notwendigkeit einer Freigabe zu spezifizieren.
 
 ## Beispiel der Erweiterung um eine Personalnummer
 


### PR DESCRIPTION
Verschiedene Datenmodelle wurden von "für Diensteanbieter" auf "für Dienste" geändert, um konsistent mit den Namen anderer Datenmodelle zu sein.