### PR TITLE
#419 Zyklische Navigation bei doppelt gelisteten APIs

### DIFF
--- a/sidebars.ts
+++ b/sidebars.ts
@@ -629,18 +629,6 @@ const sidebars: SidebarsConfig = {
           items: [
             {
               type: 'doc',
-              id: 'generated/openapi/quellsysteme/create-gruppe-id-gruppenzugehoerigkeit',
-              label: '/gruppen/\u200B:id/\u200Bgruppenzugehoerigkeiten',
-              className: 'api-method post',
-            },
-            {
-              type: 'doc',
-              id: 'generated/openapi/quellsysteme/read-gruppe-id-gruppenzugehoerigkeiten',
-              label: '/gruppen/\u200B:id/\u200Bgruppenzugehoerigkeiten',
-              className: 'api-method get',
-            },
-            {
-              type: 'doc',
               id: 'generated/openapi/quellsysteme/read-gruppenzugehoerigkeiten',
               label: '/gruppenzugehoerigkeiten',
               className: 'api-method get',
@@ -669,18 +657,6 @@ const sidebars: SidebarsConfig = {
           type: 'category',
           label: 'Sichtfreigaben',
           items: [
-            {
-              type: 'doc',
-              id: 'generated/openapi/quellsysteme/create-personenkontext-id-sichtfreigabe',
-              label: '/personenkontexte/\u200B:id/\u200Bsichtfreigaben',
-              className: 'api-method post',
-            },
-            {
-              type: 'doc',
-              id: 'generated/openapi/quellsysteme/read-personenkontext-id-sichtfreigaben',
-              label: '/personenkontexte/\u200B:id/\u200Bsichtfreigaben',
-              className: 'api-method get',
-            },
             {
               type: 'doc',
               id: 'generated/openapi/quellsysteme/delete-sichtfreigabe-id',

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -645,7 +645,7 @@ const sidebars: SidebarsConfig = {
           type: 'category',
           label: 'Sichtfreigaben',
           items: [
-                     {
+            {
               type: 'doc',
               id: 'generated/openapi/quellsysteme/create-personenkontext-id-sichtfreigabe',
               label: '/personenkontexte/\u200B:id/\u200Bsichtfreigaben',

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -531,18 +531,6 @@ const sidebars: SidebarsConfig = {
               label: '/personenkontexte/\u200B:id/\u200Bbeziehungen',
               className: 'api-method get',
             },
-            {
-              type: 'doc',
-              id: 'generated/openapi/quellsysteme/create-personenkontext-id-sichtfreigabe',
-              label: '/personenkontexte/\u200B:id/\u200Bsichtfreigaben',
-              className: 'api-method post',
-            },
-            {
-              type: 'doc',
-              id: 'generated/openapi/quellsysteme/read-personenkontext-id-sichtfreigaben',
-              label: '/personenkontexte/\u200B:id/\u200Bsichtfreigaben',
-              className: 'api-method get',
-            },
           ],
         },
         {
@@ -609,6 +597,12 @@ const sidebars: SidebarsConfig = {
               label: '/gruppen/\u200B:id',
               className: 'api-method delete',
             },
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Gruppenzugehörigkeiten',
+          items: [
             {
               type: 'doc',
               id: 'generated/openapi/quellsysteme/create-gruppe-id-gruppenzugehoerigkeit',
@@ -621,12 +615,6 @@ const sidebars: SidebarsConfig = {
               label: '/gruppen/\u200B:id/\u200Bgruppenzugehoerigkeiten',
               className: 'api-method get',
             },
-          ],
-        },
-        {
-          type: 'category',
-          label: 'Gruppenzugehörigkeiten',
-          items: [
             {
               type: 'doc',
               id: 'generated/openapi/quellsysteme/read-gruppenzugehoerigkeiten',
@@ -657,6 +645,18 @@ const sidebars: SidebarsConfig = {
           type: 'category',
           label: 'Sichtfreigaben',
           items: [
+                     {
+              type: 'doc',
+              id: 'generated/openapi/quellsysteme/create-personenkontext-id-sichtfreigabe',
+              label: '/personenkontexte/\u200B:id/\u200Bsichtfreigaben',
+              className: 'api-method post',
+            },
+            {
+              type: 'doc',
+              id: 'generated/openapi/quellsysteme/read-personenkontext-id-sichtfreigaben',
+              label: '/personenkontexte/\u200B:id/\u200Bsichtfreigaben',
+              className: 'api-method get',
+            },
             {
               type: 'doc',
               id: 'generated/openapi/quellsysteme/delete-sichtfreigabe-id',


### PR DESCRIPTION
Ich habe die doppelt gelisteten APIs entfernt, d.h. /personenkontexte/:id/sichtfreigaben erscheint nur noch unter Personenkontexte, nicht mehr unter Sichtfreigaben. 
Entsprechend auch für die Gruppenzugehörigkeiten unter /gruppen/:id/gruppenzugehoerigkeiten. 

Es ist nicht mehr ganz nachzuvollziehen, warum die APIs zwei Mal im Navigationsbalken auftauchen. 

Ist das weiter so gewünscht und die zyklische Navigation soll beseitigt werden, so ist die Lösung wahrscheinlich jeweils zwei Seiten anzulegen (eine für Personenkontext und eine unter Sichtfreigabe), welche jeweils die jetzige Seite includen. Dadurch würde der Inhalt nicht gedoppelt (d.h. eine Modifikation an der API taucht an beiden Stellen auf), aber da jeder Eintrag eine 'eigene Seite' hat, sollte die Navigation dann korrekt funktionieren. 

Aber erstmal der offensichtliche Fix - die doppelt gelisteten APIs entfernen.