### PR TITLE
#411: Versionsauswahl von der Startseite wird nicht übernommen in Spezifikation

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -165,7 +165,7 @@ const config: Config = {
         style: 'dark',
         links: [
           {
-            title: 'Schulconnex',
+            title: 'Schulconnex (v1.6)',
             items: [
               {
                 label: 'Einleitung',

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -165,7 +165,7 @@ const config: Config = {
         style: 'dark',
         links: [
           {
-            title: 'Schulconnex (v1.6)',
+            title: 'Schulconnex (Version 1.6)',
             items: [
               {
                 label: 'Einleitung',

--- a/package-lock.json
+++ b/package-lock.json
@@ -22350,9 +22350,10 @@
       }
     },
     "node_modules/unist-util-visit": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
-      "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
         "unist-util-is": "^6.0.0",

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -45,7 +45,7 @@ export default function Home() {
                   className="button button--secondary button--lg"
                   to={`/docs/einleitung`}
                 >
-                  zur Spezifikation
+                  zur Spezifikation (V1.6)
                 </Link>
               </div>
             </div>{' '}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -45,7 +45,7 @@ export default function Home() {
                   className="button button--secondary button--lg"
                   to={`/docs/einleitung`}
                 >
-                  zur Spezifikation (V1.6)
+                  zur Spezifikation (Version 1.6)
                 </Link>
               </div>
             </div>{' '}


### PR DESCRIPTION
Im Footer der Seite wird jetzt auch die Versionsnummer angezeigt, um zu verdeutlichen, dass man über den Link immer zur aktuell gültigen Version kommt, auch wenn man vorher in 1.7 RC1 unterwegs war.
