### PR TITLE
#428 Unklare Navigation von Versionshistorie durch Doppelung

### DIFF
--- a/sidebars.ts
+++ b/sidebars.ts
@@ -275,7 +275,6 @@ const sidebars: SidebarsConfig = {
         'praxisleitfaden/ablauf-löschen',
       ],
     },
-    'versionshistorie',
   ],
 
   spezPoliciesSidebar: [


### PR DESCRIPTION
Da es wenig Sinn macht die Versionshistorie ein zweites Mal unter den Quellsystemen aufzuführen (auch weil wir keine getrennten Historien für Dienste und Quellsysteme führen), wurde die zweite Referenz auf die Seite entfernt.