### PR TITLE
#412 Anzahl der Dokumente mit einem Tag wird in Dokusaurus falsch ang…

### DIFF
--- a/docs/lizenzerweiterung/schnittstellen/schnittstellen.md
+++ b/docs/lizenzerweiterung/schnittstellen/schnittstellen.md
@@ -1,7 +1,5 @@
 ---
 title: ''
-tags:
-- Verbindlich
 ---
 
 import Text from '../../schnittstellen/schnittstellen.md';

--- a/docs/schnittstellendefinition/http-statuscodes-dienste.md
+++ b/docs/schnittstellendefinition/http-statuscodes-dienste.md
@@ -1,7 +1,5 @@
 ---
 title: ''
-tags:
-- Verbindlich
 ---
 
 import Text from './http-statuscodes.md';

--- a/docs/schnittstellendefinition/http-statuscodes-qs.md
+++ b/docs/schnittstellendefinition/http-statuscodes-qs.md
@@ -1,7 +1,5 @@
 ---
 title: ''
-tags:
-- Verbindlich
 ---
 
 import Text from './http-statuscodes.md';

--- a/docs/schnittstellendefinition/schnittstellendefinition-dienste.md
+++ b/docs/schnittstellendefinition/schnittstellendefinition-dienste.md
@@ -1,7 +1,5 @@
 ---
 title: ''
-tags:
-- Verbindlich
 ---
 
 import Text from './schnittstellendefinition.md';

--- a/docs/schnittstellendefinition/schnittstellendefinition-qs.md
+++ b/docs/schnittstellendefinition/schnittstellendefinition-qs.md
@@ -1,7 +1,5 @@
 ---
 title: ''
-tags:
-- Verbindlich
 ---
 
 import Text from './schnittstellendefinition.md';

--- a/docs/schnittstellendefinition/validierung-dienste.md
+++ b/docs/schnittstellendefinition/validierung-dienste.md
@@ -1,7 +1,5 @@
 ---
 title: ''
-tags:
-- Verbindlich
 ---
 
 import Text from './validierung.md';

--- a/docs/schnittstellendefinition/validierung-qs.md
+++ b/docs/schnittstellendefinition/validierung-qs.md
@@ -1,7 +1,5 @@
 ---
 title: ''
-tags:
-- Verbindlich
 ---
 
 import Text from './validierung.md';


### PR DESCRIPTION
…ezeigt

Tag 'verbindlich' als allen Dateien entfernt, welche andere Dokumente mit demselben Tag nur importieren und selber keinen Text enthalten.