### PR TITLE
#449 Erzeugung von YAML Datei für Nutzungsrechte API

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,17 @@ Für die Quellsysteme-API:
 npm run write-dereferenced-openapi-for-qs
 ```
 
+Für die Nutzungsrechte-API:
+
+```bash
+npm run write-dereferenced-openapi-for-policies
+```
+
+Für alle drei APIs gleichzeitig:
+```bash
+npm run write-dereferenced-openapi
+```
+
 ## Deployment
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "clean-openapi-docs": "git clean -dxf -- docs/generated/",
     "write-dereferenced-openapi-for-qs": "redocly bundle --dereferenced --remove-unused-components src/openapi/api-qs.yaml | node util/resolve-relative-urls.js > static/dist/openapi/api-qs.yaml",
     "write-dereferenced-openapi-for-dienste": "redocly bundle --dereferenced --remove-unused-components src/openapi/api-dienste.yaml | node util/resolve-relative-urls.js > static/dist/openapi/api-dienste.yaml",
-    "write-dereferenced-openapi": "npm run write-dereferenced-openapi-for-dienste && npm run write-dereferenced-openapi-for-qs",
+    "write-dereferenced-openapi-for-policies": "redocly bundle --dereferenced --remove-unused-components src/openapi/api-policies.yaml | node util/resolve-relative-urls.js > static/dist/openapi/api-nutzungsrechte.yaml",
+    "write-dereferenced-openapi": "npm run write-dereferenced-openapi-for-dienste && npm run write-dereferenced-openapi-for-qs && npm run write-dereferenced-openapi-for-policies",
     "validate-openapi": "npx @redocly/cli lint src/openapi/api-dienste.yaml src/openapi/api-qs.yaml"
   },
   "dependencies": {


### PR DESCRIPTION
Das Kommando "npm run write-dereferenced-openapi" generiert jetzt auch die eigenständig herunterladbare Nutzungsrechte-API `api-nutzungsrechte.yaml`.