### PR TITLE
#448 / #412 Tag 'verbindlich' wird nicht konsistent genutzt

### DIFF
--- a/docs/datenmodell-qs/anschrift.md
+++ b/docs/datenmodell-qs/anschrift.md
@@ -1,3 +1,7 @@
+---
+tags:
+- Verbindlich
+---
 # Anschrift
 
 Die Anschrift erlaubt es, einen Ort zu beschreiben, an dem, beispielsweise, eine Organisation ansässig ist.

--- a/docs/datenmodell-qs/beziehung.md
+++ b/docs/datenmodell-qs/beziehung.md
@@ -1,3 +1,7 @@
+---
+tags:
+- Verbindlich
+---
 # Beziehung
 
 Das Datenmodell Beziehung beschreibt die Beziehung zweier Personen. Die Beziehungen werden zwischen

--- a/docs/datenmodell-qs/datumsformat.md
+++ b/docs/datenmodell-qs/datumsformat.md
@@ -1,3 +1,7 @@
+---
+tags:
+- Verbindlich
+---
 # Datumsformat
 
 Alle Datumsangaben werden entsprechend der ISO-8601-Formatierung `YYYY-MM-DD` dargestellt. Sie beinhalten

--- a/docs/datenmodell-qs/erreichbarkeit.md
+++ b/docs/datenmodell-qs/erreichbarkeit.md
@@ -1,3 +1,7 @@
+---
+tags:
+- Verbindlich
+---
 # Erreichbarkeit
 
 Erreichbarkeit für einen Personenkontext.

--- a/docs/datenmodell-qs/fach.md
+++ b/docs/datenmodell-qs/fach.md
@@ -1,3 +1,7 @@
+---
+tags:
+- Verbindlich
+---
 # Fach
 
 Ein behandeltes Fach.

--- a/docs/datenmodell-qs/geburt.md
+++ b/docs/datenmodell-qs/geburt.md
@@ -1,3 +1,7 @@
+---
+tags:
+- Verbindlich
+---
 # Geburt
 
 Datenmodell der Geburt einer [Person](person).

--- a/docs/datenmodell-qs/gruppe.md
+++ b/docs/datenmodell-qs/gruppe.md
@@ -1,3 +1,7 @@
+---
+tags:
+- Verbindlich
+---
 # Gruppe
 
 Eine Gruppe erlaubt es, mehrere Personen in einer Gruppe zusammenzufassen. Typischerweise handelt es sich

--- a/docs/datenmodell-qs/gruppendatensatz.md
+++ b/docs/datenmodell-qs/gruppendatensatz.md
@@ -1,3 +1,7 @@
+---
+tags:
+- Verbindlich
+---
 # Gruppendatensatz
 
 Datenmodell eines Gruppendatensatzes: Der Gruppendatensatz ist als Daten-Container (WrapperObject) zu verstehen.

--- a/docs/datenmodell-qs/gruppenzugehörigkeit.md
+++ b/docs/datenmodell-qs/gruppenzugehörigkeit.md
@@ -1,3 +1,7 @@
+---
+tags:
+- Verbindlich
+---
 # Gruppenzugehörigkeit
 
 Die Gruppenzugehörigkeit repräsentiert eine Verknüpfung zwischen einem Personenkontext und einer Gruppe.

--- a/docs/datenmodell-qs/laufzeit.md
+++ b/docs/datenmodell-qs/laufzeit.md
@@ -1,3 +1,7 @@
+---
+tags:
+- Verbindlich
+---
 # Laufzeit
 
 Die Laufzeiten von Gruppen können entweder direkt durch Datumsangaben festgelegt werden (`von`/`bis`) oder

--- a/docs/datenmodell-qs/lernperiode.md
+++ b/docs/datenmodell-qs/lernperiode.md
@@ -1,3 +1,7 @@
+---
+tags:
+- Verbindlich
+---
 # Lernperiode
 
 Eine Lernperiode beschreibt einen Zeitraum, in dem Gruppen von Organisationen angeboten werden können.

--- a/docs/datenmodell-qs/name.md
+++ b/docs/datenmodell-qs/name.md
@@ -1,3 +1,7 @@
+---
+tags:
+- Verbindlich
+---
 # Name
 
 Datenmodell des Namens einer [Person](person).

--- a/docs/datenmodell-qs/organisation.md
+++ b/docs/datenmodell-qs/organisation.md
@@ -1,3 +1,7 @@
+---
+tags:
+- Verbindlich
+---
 # Organisation
 
 Eine Organisation stellt eine Schule oder sonstige relevante Organisation im Kontext eines

--- a/docs/datenmodell-qs/organisationsbeziehung.md
+++ b/docs/datenmodell-qs/organisationsbeziehung.md
@@ -1,3 +1,7 @@
+---
+tags:
+- Verbindlich
+---
 # Organisationsbeziehung
 
 Das Datenmodell Organisationsbeziehung beschreibt die Beziehung zweier Organisationen.

--- a/docs/datenmodell-qs/person.md
+++ b/docs/datenmodell-qs/person.md
@@ -1,3 +1,7 @@
+---
+tags:
+- Verbindlich
+---
 # Person
 
 Nachfolgend ist das Datenmodell einer Person dargestellt.

--- a/docs/datenmodell-qs/personendatensatz.md
+++ b/docs/datenmodell-qs/personendatensatz.md
@@ -1,3 +1,7 @@
+---
+tags:
+- Verbindlich
+---
 # Personendatensatz
 
 Datenmodell eines Personendatensatzes: Personendatensatz ist als Daten-Container (WrapperObject) zu verstehen.

--- a/docs/datenmodell-qs/personenkontext.md
+++ b/docs/datenmodell-qs/personenkontext.md
@@ -1,3 +1,7 @@
+---
+tags:
+- Verbindlich
+---
 # Personenkontext
 
 Der Personenkontext gibt an, in welcher Rolle der Dienst von nutzenden Personen in Anspruch genommen wird.

--- a/docs/datenmodell-qs/referenzgruppe.md
+++ b/docs/datenmodell-qs/referenzgruppe.md
@@ -1,3 +1,7 @@
+---
+tags:
+- Verbindlich
+---
 # Referenzgruppe
 
 Bei Referenzgruppen handelt es sich um Gruppen, deren Gruppenzugehörige vollständig oder teilweise der

--- a/docs/datenmodell-qs/sichtfreigabe.md
+++ b/docs/datenmodell-qs/sichtfreigabe.md
@@ -1,3 +1,7 @@
+---
+tags:
+- Verbindlich
+---
 # Sichtfreigabe
 
 Datenmodell einer Sichtfreigabe.

--- a/docs/lizenzerweiterung/schnittstellendefinition/http-statuscodes.md
+++ b/docs/lizenzerweiterung/schnittstellendefinition/http-statuscodes.md
@@ -1,5 +1,7 @@
 ---
 title: ''
+tags:
+- Verbindlich
 ---
 
 import Text from '../../schnittstellendefinition/http-statuscodes.md';

--- a/docs/lizenzerweiterung/schnittstellendefinition/schnittstellendefinition.md
+++ b/docs/lizenzerweiterung/schnittstellendefinition/schnittstellendefinition.md
@@ -1,5 +1,7 @@
 ---
 title: ''
+tags:
+- Verbindlich
 ---
 
 import Text from '../../schnittstellendefinition/schnittstellendefinition.md';

--- a/docs/versionshistorie.md
+++ b/docs/versionshistorie.md
@@ -1,3 +1,7 @@
+---
+tags:
+- Informativ
+---
 # Versionshistorie
 
 Die Versionshistorie beschreibt die wichtigsten inhaltlichen Änderungen zwischen den veröffentlichten Versionen von Schulconnex.


### PR DESCRIPTION
Alle Datenmodelle wurden als `verbindlich` getaggt. 
Schnittstellendefinition und HTTP-Statuscodes bei der Nutzungsrechte-API wurden als `verbindlich` getaggt, um konsistent mit den entsprechenden Seiten bei QS und Dienste zu sein. 
Die Versionshistorie wurde als `Informativ` getaggt.

Damit sind noch nicht alle Seiten getaggt, insbesondere sind noch `Codelisten` ohne Tag und vermutlich gibt es keine einfache Lösung alle OpenAPI Seiten in Docusaurus zu taggen, aber das Tagging ist jetzt weitreichender und informativer.

Ein Nachteil ist allerdings dass dadurch die Zählung der getaggten Seiten in Docusaurus wieder ungenau wird.
Momentan wird angezeigt `34 docs getaggt mit "Verbindlich"`, es werden aber nur 24 Links gelistet.

Das entsteht daher, dass Quellsystemseiten bei den Diensten importiert werden, also beispielsweise:
`datenmodell-dienste/lernperiode.md importiert '../datenmodell-qs/lernperiode.md'`
In diesem Fall 'sieht' Docusaurus zweimal den `verbindlich` Tag uns nimmt den auch in die Summe auf, die Seite wird aber nur einmal gelistet.

Theoretisch kann man das  vermutlich vermeiden, wenn sowohl Dienste als auch Quellsysteme die Datenmodelle importieren.
```
`datenmodell-dienste/lernperiode.md importiert '../datenmodell-gemeinsam/lernperiode.md'`
`datenmodell-qs/lernperiode.md importiert '../datenmodell-gemeinsam/lernperiode.md'`
```
Aber jetzt für jedes Datenmodell noch mal eine zusätzliche Datei anzulegen, nur damit die Gesamtzahlanzeige für verwendete Tags mit der Anzahl der gezeigten Links anzeigt, ist den Aufwand nicht wert.

