### PR TITLE
#467 Barrierefreiheit (Farbkontraste) Lizenzangabe

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -204,7 +204,7 @@ const config: Config = {
             ],
           }
         ],
-        copyright: '<a href=https://creativecommons.org/licenses/by-nd/4.0/legalcode target=_blank>CC BY-ND 4.0</a>',
+        copyright: '<a href="https://creativecommons.org/licenses/by-nd/4.0/legalcode"; style="color:#bfadf7;" target=_blank>CC BY-ND 4.0</a>',
       },
       prism: {
         theme: prismThemes.github,

--- a/package-lock.json
+++ b/package-lock.json
@@ -22350,9 +22350,10 @@
       }
     },
     "node_modules/unist-util-visit": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
-      "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
         "unist-util-is": "^6.0.0",


### PR DESCRIPTION
Lizenzangabe Farbe fest auf Link-Farbe für "Dark" gesetzt. 

Die Lösung ist nicht sonderlich elegant, aber leider nutzt Docusaurus für den das "Copyright:" Tag eigenen HTML Code, der sich unabhängig von den anderen Footer-Elementen verhält. 

Für den Footer ist als Farbschema fest 'Dark' gesetzt, was auch für alle Elemente des Footers übernommen wird, aber eben nicht für den Copyright-Link, der abhängig von der allgemeinen Seitendarstellung die Farbe bei Light/Dark wechselt. 

Daher ist die Lösung auch bei dem Link (wie bei 'Dark' für den Footer allgemein) das Farbschema fest zu setzen.
(Setzen über CSS ist problematisch, da sich das auf alle Links (und nicht nur den Copyright-Link im Footer) auswirken würde,)