### PR TITLE
#463 Im Hauptmenü den Eintrag "Schulconnex" entfernen

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -70,7 +70,6 @@ const config: Config = {
   themeConfig:
     {
       navbar: {
-        title: 'Schulconnex',
         logo: {
           alt: 'Schulconnex',
           src: 'img/logo.svg',

--- a/package-lock.json
+++ b/package-lock.json
@@ -22350,9 +22350,10 @@
       }
     },
     "node_modules/unist-util-visit": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
-      "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
         "unist-util-is": "^6.0.0",


### PR DESCRIPTION
Der Text "Schulconnex" steht jetzt in der Headerzeile nicht mehr neben dem Schulconnex-Logo, da beide Links auf dieselbe Seite führen und damit Funktion und Inhalt doppeln. Package-lock.json upgedated, um automatischen Deployment-Check zu reaktivieren.