### PR TITLE
#350: Fix JSON-Codebeispiel-Einrückung mit "// line-highlight#480

### DIFF
--- a/docs/lizenzerweiterung/praxisleitfaden/odrl-beispiele.mdx
+++ b/docs/lizenzerweiterung/praxisleitfaden/odrl-beispiele.mdx
@@ -63,10 +63,10 @@ Die Eigenschaft `@type` gibt den Typ des ODRL-Objekts an. In diesem Fall ist der
 
 <Tabs groupId="accept-type" queryString>
   <TabItem value="json" label="JSON">
-    <CodeBlock language="js" title="Beispiel für eine Schullizenz" >{Schullizenz}</CodeBlock>
+    <CodeBlock language="js" title="Beispiel für eine Schullizenz" showLineNumbers>{Schullizenz}</CodeBlock>
   </TabItem>
   <TabItem value="json-ld" label="JSON LD">
-    <CodeBlock language="js" title="Beispiel für eine Schullizenz" >{SchullizenzLD}</CodeBlock>
+    <CodeBlock language="js" title="Beispiel für eine Schullizenz" showLineNumbers>{SchullizenzLD}</CodeBlock>
   </TabItem>
 </Tabs>
 
@@ -96,10 +96,10 @@ Die Struktur innerhalb des `permission`-Blocks bedeutet also, dass die Erlaubnis
 
 <Tabs groupId="accept-type" queryString>
   <TabItem value="json" label="JSON">
-    <CodeBlock language="js" title="Beispiel für eine Lehrerlizenz" >{Lehrerlizenz}</CodeBlock>
+    <CodeBlock language="js" title="Beispiel für eine Lehrerlizenz" showLineNumbers>{Lehrerlizenz}</CodeBlock>
   </TabItem>
   <TabItem value="json-ld" label="JSON LD">
-    <CodeBlock language="js" title="Beispiel für eine Lehrerlizenz" >{LehrerlizenzLD}</CodeBlock>
+    <CodeBlock language="js" title="Beispiel für eine Lehrerlizenz" showLineNumbers>{LehrerlizenzLD}</CodeBlock>
   </TabItem>
 </Tabs>
 
@@ -119,10 +119,10 @@ Diese Konfiguration bedeutet also, dass die Erlaubnis zur Ausführung des durch 
 
 <Tabs groupId="accept-type" queryString>
   <TabItem value="json" label="JSON">
-    <CodeBlock language="js" title="Beispiel für eine Gruppenlizenz" >{Gruppenlizenz}</CodeBlock>
+    <CodeBlock language="js" title="Beispiel für eine Gruppenlizenz" showLineNumbers>{Gruppenlizenz}</CodeBlock>
   </TabItem>
   <TabItem value="json-ld" label="JSON LD">
-    <CodeBlock language="js" title="Beispiel für eine Gruppenlizenz" >{GruppenlizenzLD}</CodeBlock>
+    <CodeBlock language="js" title="Beispiel für eine Gruppenlizenz" showLineNumbers>{GruppenlizenzLD}</CodeBlock>
   </TabItem>
 </Tabs>
 
@@ -165,10 +165,10 @@ Alternativ: */}
 
 <Tabs groupId="accept-type" queryString>
   <TabItem value="json" label="JSON">
-    <CodeBlock language="js" title="Beispiel für ein gestreamtes Medium" >{AVMedium}</CodeBlock>
+    <CodeBlock language="js" title="Beispiel für ein gestreamtes Medium" showLineNumbers>{AVMedium}</CodeBlock>
   </TabItem>
   <TabItem value="json-ld" label="JSON LD">
-    <CodeBlock language="js" title="Beispiel für ein gestreamtes Medium" >{AVMediumLD}</CodeBlock>
+    <CodeBlock language="js" title="Beispiel für ein gestreamtes Medium" showLineNumbers>{AVMediumLD}</CodeBlock>
   </TabItem>
 </Tabs>
 
@@ -184,10 +184,10 @@ Es ist wichtig zu beachten, dass dieses Beispiel keine Einschränkungen bezügli
 
 <Tabs groupId="accept-type" queryString>
   <TabItem value="json" label="JSON">
-    <CodeBlock language="js" title="Beispiel für ein bearbeitbares Office-Dokument" >{Arbeitsblatt}</CodeBlock>
+    <CodeBlock language="js" title="Beispiel für ein bearbeitbares Office-Dokument" showLineNumbers>{Arbeitsblatt}</CodeBlock>
   </TabItem>
   <TabItem value="json-ld" label="JSON LD">
-    <CodeBlock language="js" title="Beispiel für ein bearbeitbares Office-Dokument" >{ArbeitsblattLD}</CodeBlock>
+    <CodeBlock language="js" title="Beispiel für ein bearbeitbares Office-Dokument" showLineNumbers>{ArbeitsblattLD}</CodeBlock>
   </TabItem>
 </Tabs>
 
@@ -207,10 +207,10 @@ Dieses Beispiel erlaubt also die Nutzung, Vervielfältigung und Weitergabe eines
 
 <Tabs groupId="accept-type" queryString>
   <TabItem value="json" label="JSON">
-    <CodeBlock language="js" title="Beispiel für eine Schuljahreslizenz" >{Schuljahreslizenz}</CodeBlock>
+    <CodeBlock language="js" title="Beispiel für eine Schuljahreslizenz" showLineNumbers>{Schuljahreslizenz}</CodeBlock>
   </TabItem>
   <TabItem value="json-ld" label="JSON LD">
-    <CodeBlock language="js" title="Beispiel für eine Schuljahreslizenz" >{SchuljahreslizenzLD}</CodeBlock>
+    <CodeBlock language="js" title="Beispiel für eine Schuljahreslizenz" showLineNumbers>{SchuljahreslizenzLD}</CodeBlock>
   </TabItem>
 </Tabs>
 
@@ -228,10 +228,10 @@ In der Zusammenschau bewirken diese beiden Constraints, dass die Erlaubnis zur A
 
 <Tabs groupId="accept-type" queryString>
   <TabItem value="json" label="JSON">
-    <CodeBlock language="js" title="Beispiel für eine kreisweit gültige Lizenz" >{Landkreis}</CodeBlock>
+    <CodeBlock language="js" title="Beispiel für eine kreisweit gültige Lizenz" showLineNumbers>{Landkreis}</CodeBlock>
   </TabItem>
   <TabItem value="json-ld" label="JSON LD">
-    <CodeBlock language="js" title="Beispiel für eine kreisweit gültige Lizenz" >{LandkreisLD}</CodeBlock>
+    <CodeBlock language="js" title="Beispiel für eine kreisweit gültige Lizenz" showLineNumbers>{LandkreisLD}</CodeBlock>
   </TabItem>
 </Tabs>
 
@@ -247,10 +247,10 @@ In der Gesamtbetrachtung bedeutet dieses Constraint, dass die Erlaubnis zur Ausf
 
 <Tabs groupId="accept-type" queryString>
   <TabItem value="json" label="JSON">
-    <CodeBlock language="js" title="Beispiel für eine dynamisch zugeteilte Lizenz" >{Dynamisch}</CodeBlock>
+    <CodeBlock language="js" title="Beispiel für eine dynamisch zugeteilte Lizenz" showLineNumbers>{Dynamisch}</CodeBlock>
   </TabItem>
   <TabItem value="json-ld" label="JSON LD">
-    <CodeBlock language="js" title="Beispiel für eine dynamisch zugeteilte Lizenz" >{DynamischLD}</CodeBlock>
+    <CodeBlock language="js" title="Beispiel für eine dynamisch zugeteilte Lizenz" showLineNumbers>{DynamischLD}</CodeBlock>
   </TabItem>
 </Tabs>
 
@@ -272,10 +272,10 @@ In der Gesamtbetrachtung bedeutet dieses Constraint, dass die Erlaubnis zur Ausf
 
 <Tabs groupId="accept-type" queryString>
   <TabItem value="json" label="JSON">
-    <CodeBlock language="js" title="Beispiel für eine Kombination von Lizenzbedingungen" >{Kombiniert}</CodeBlock>
+    <CodeBlock language="js" title="Beispiel für eine Kombination von Lizenzbedingungen" showLineNumbers>{Kombiniert}</CodeBlock>
   </TabItem>
   <TabItem value="json-ld" label="JSON LD">
-    <CodeBlock language="js" title="Beispiel für eine Kombination von Lizenzbedingungen" >{KombiniertLD}</CodeBlock>
+    <CodeBlock language="js" title="Beispiel für eine Kombination von Lizenzbedingungen" showLineNumbers>{KombiniertLD}</CodeBlock>
   </TabItem>
 </Tabs>
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -118,3 +118,7 @@
 [data-theme='light'] {
   --github-logo-color-primary: #000000;
 }
+
+code[class*='codeBlockLinesWithNumbering'] > .theme-code-block-highlighted-line {
+  display: table-row;
+}


### PR DESCRIPTION
Nach langem Dialog auf Discord (mit besten Dank an User "Bankai-Tech") ist das Problem jetzt zumindest erkannt und umgangen. 

Das Highlighting braucht "display: table-row", aber irgendetwas (vermutlich das CSS für die Zeilennummern) setzt statt dessen "display: block", was zu dem Layout-Problem führt. Anscheinend (aber das ist aktuell noch unklar) werden die CSS Attribute in einer anderen Reihenfolge eingebunden, wenn man ein "Bundle" baut als wenn man Docusaurus lokal startet. 

Der Fix ist einfach in CUSTOM.CSS explizt den Wert für "display" auf "table-row" zu setzen. Und zwar ausschliesslich für Highlight-Lines in Codeblöcken mir Zeilennummerierung, so dass durch das Update nirgendwo sonst Nebeneffekte auftreten sollten. 

In meiner lokalen Umgebung wird dadurch das Problem behoben, daher habe ich die 'showLineNumbers' Attribute wieder in den ODRL-Praxisleitfaden eingebaut.