### PR TITLE
#483 Verlinkungen auf https://login.schulconnex.test/ enthalten sichtbar &zwj;

### DIFF
--- a/src/openapi/api-dienste.yaml
+++ b/src/openapi/api-dienste.yaml
@@ -11,7 +11,7 @@ info:
     name: Creative Commons Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)
     url: https://creativecommons.org/licenses/by-nd/4.0/legalcode
 servers:
-  - url: https&zwj;://schulconnex.test/v1
+  - url: https://schulconnex.test/v1
     description: Lokaler Testserver
 security:
   - oAuthForServices: []

--- a/src/openapi/api-policies.yaml
+++ b/src/openapi/api-policies.yaml
@@ -11,7 +11,7 @@ info:
     name: Creative Commons Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)
     url: https://creativecommons.org/licenses/by-nd/4.0/legalcode
 servers:
-  - url: https&zwj;://schulconnex.test/v1
+  - url: https://schulconnex.test/v1
     description: Lokaler Testserver
 security:
   - oAuthForServices: []

--- a/src/openapi/api-qs.yaml
+++ b/src/openapi/api-qs.yaml
@@ -11,7 +11,7 @@ info:
     name: Creative Commons Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)
     url: https://creativecommons.org/licenses/by-nd/4.0/legalcode
 servers:
-  - url: https&zwj;://schulconnex.test/v1
+  - url: https://schulconnex.test/v1
     description: Lokaler Testserver
 security:
   - oAuthForServices: []


### PR DESCRIPTION
&zwj; aus den schulconnex.test Pseudo-URLs entfernt.