### PR TITLE
#481 API Sichtfreigaben: Berechtigungen klären

### DIFF
--- a/docs/allgemeines-datenschutz.md
+++ b/docs/allgemeines-datenschutz.md
@@ -19,6 +19,6 @@ Technische Identifier für Datenobjekte werden für jeden Dienst einzeln pseudon
 Die Bereitstellung von Daten einer Organisation an eine andere Organisation muss explizit über eine Sichtfreigabe erfolgen, die jederzeit widerrufen werden kann. Sichtfreigaben erlauben anderen Organisationen nur lesenden Zugriff.
 
 ## Möglichkeit der Auskunftssperre
-Für Personen mit besonderem Schutzbedarf besteht die Möglichkeit eine Auskunftssperre zu setzen, um die Übertragung von Informationen an andere Quellsysteme oder Dienste zu blockieren.
+Für Personen mit besonderem Schutzbedarf besteht die Möglichkeit, eine Auskunftssperre zu setzen, um die Übertragung von Informationen an andere Quellsysteme oder Dienste zu blockieren.
 
 Weiterhin stellt die Schulconnex-Spezifikation einen informativen Praxisleitfaden für die Implementierung der  Abläufe zum Löschen von Personen-Daten und Personenkontext-Daten bereit, sowie Mechanismen diese Löschanforderungen auch an Dienste zu liefern, welche die Daten bereits genutzt haben und eventuell lokale Kopien halten.

--- a/docs/allgemeines-datenschutz.md
+++ b/docs/allgemeines-datenschutz.md
@@ -7,17 +7,22 @@ tags:
 
 Neben den gebräuchlichen technischen-organisatorischen Maßnahmen beim Betrieb von Schulconnex-Servern, unterstützt die Schulconnex-Spezifikation den Datenschutz bereits durch eine Reihe von Designentscheidungen.
 
-Insbesondere beinhalten diese als verbindliche Vorgaben:
-* Datensparsamkeit als Grundprinzip (Privacy by Design und Privacy by Default)
+## Datensparsamkeit als Grundprinzip (Privacy by Design und Privacy by Default)
 Prinzipiell werden an Dienste nur Daten ausgeliefert, welche von dem Dienst auch benötigt werden. Für jedes Datenmodell wird zwischen dem Server-Betreiber und dem Dienstanbieter individuell vertraglich festgelegt, welche Daten dem Dienst bereitgestellt werden.
+
 Für alle nicht technisch notwendigen Attribute eines Datenmodells ist eine explizite Freigabe des Attributes notwendig. Die Standardeinstellung ist somit die Nicht-Bereitstellung von Daten.
 
-* Technische Identifier für Datenobjekte werden für jeden Dienst einzeln pseudonymisiert und gelten ausschließlich für diesen Dienst.
+## Individuell pseudonymisierte Identifier für Dienste
+Technische Identifier für Datenobjekte werden für jeden Dienst einzeln pseudonymisiert und gelten ausschließlich für diesen Dienst.
 
-* Die Bereitstellung von Daten einer Organisation an eine andere Organisation muss explizit über eine Sichtfreigabe erfolgen, die jederzeit widerrufen werden kann. Sichtfreigaben erlauben anderen Organisationen nur lesenden Zugriff.
+## Explizite Sichtfreigabe für andere Organisationen
+Die Bereitstellung von Daten einer Organisation an eine andere Organisation muss explizit über eine Sichtfreigabe erfolgen, die jederzeit widerrufen werden kann. Sichtfreigaben erlauben anderen Organisationen nur lesenden Zugriff.
 
-* Für Personen mit besonderem Schutzbedarf besteht die Möglichkeit eine Auskunftssperre zu setzen, um die Übertragung von Informationen an andere Quellsysteme oder Dienste zu blockieren.
+## Möglichkeit der Auskunftssperre
+Für Personen mit besonderem Schutzbedarf besteht die Möglichkeit eine Auskunftssperre zu setzen, um die Übertragung von Informationen an andere Quellsysteme oder Dienste zu blockieren.
 
-* Hat eine Person das Recht auf Einschränkung der Verarbeitung ihrer Daten nach Artikel 18 der EU-Datenschutz-Grundverordnung (DSGVO) in Anspruch genommen, so können diese Daten entsprechend markiert werden, so dass eine weitere Verarbeitung vorerst nicht stattfindet.
+## Einschränkung der Verarbeitung nach Artikel 18 DSGVO
+Hat eine Person das Recht auf Einschränkung der Verarbeitung ihrer Daten nach Artikel 18 der EU-Datenschutz-Grundverordnung (DSGVO) in Anspruch genommen, so können diese Daten entsprechend markiert werden, so dass eine weitere Verarbeitung vorerst nicht stattfindet.
 
-Weiterhin stellt die Schulconnex-Spezifikation einen informativen Praxisleitfaden für die Implementierung der  Abläufe zum Löschen von Personen-Daten und Personenkontext-Daten bereit, sowie Mechanismen diese Löschanforderungen auch an Dienste zu liefern, welche die Daten bereits genutzt haben und eventuell lokale Kopien halten.
+## Praxisleitfaden zum Ablauf von Löschanforderungen auch an Dienste
+Die Schulconnex-Spezifikation stellt einen informativen Praxisleitfaden für die Implementierung der Abläufe zum Löschen von Personen-Daten und Personenkontext-Daten bereit, sowie Mechanismen diese Löschanforderungen auch an Dienste zu liefern, welche die Daten bereits genutzt haben und eventuell lokale Kopien halten.

--- a/docs/datenmodell-qs/sichtfreigabe.md
+++ b/docs/datenmodell-qs/sichtfreigabe.md
@@ -6,7 +6,7 @@ tags:
 
 Sichtfreigaben für einen Personenkontext können durch die Organisation erstellt, aufgelistet oder gelöscht werden, welcher der Personenkontext zugeordnet ist (Attribut `personenkontext.organisation`). 
 
-Diese Organisation kann einer anderen Organisation (spezifiziert durch das Attribut `orgid`) eine Sichtfreigabe erteilen, welche der zweiten Organisation ermöglicht lesend auf diesen Personenkontext und den dazugehörigen Datensatz `person` zuzugreifen.
+Diese Organisation kann einer anderen Organisation (spezifiziert durch das Attribut `orgid`) eine Sichtfreigabe erteilen, welche es der zweiten Organisation ermöglicht, lesend auf diesen Personenkontext und den dazugehörigen Datensatz `person` zuzugreifen.
 
 Ein solcher Zugriff kann über die Attribute `von` und `bis` zeitlich begrenzt werden. 
 

--- a/docs/datenmodell-qs/sichtfreigabe.md
+++ b/docs/datenmodell-qs/sichtfreigabe.md
@@ -10,7 +10,7 @@ Diese Organisation kann einer anderen Organisation (spezifiziert durch das Attri
 
 Ein solcher Zugriff kann über die Attribute `von` und `bis` zeitlich begrenzt werden. 
 
-Unabhängig von dieser zeitlichen Begrenzung kann eine Sichtfreigabe jederzeit durch die DELETE API für Sichtfreigabe gelöscht werden. Dabei sind sowohl die Organisation, welche die Sichtfreigabe erteilt hat, als auch die zweite Organisation, für welche die Sichtfreigabe erteilt wurde, berechtigt diese Sichtfreigabe zu löschen.
+Unabhängig von dieser zeitlichen Begrenzung kann eine Sichtfreigabe jederzeit mit einer DELETE-Anfrage gelöscht werden. Dabei ist sowohl die Organisation, welche die Sichtfreigabe erteilt hat, als auch die zweite Organisation, welcher die Sichtfreigabe erteilt wurde, berechtigt, diese Sichtfreigabe zu löschen.
 
 Attribut | Typ | Anzahl | Bemerkung
 --- | --- | --- | ---

--- a/docs/datenmodell-qs/sichtfreigabe.md
+++ b/docs/datenmodell-qs/sichtfreigabe.md
@@ -6,6 +6,8 @@ tags:
 
 Datenmodell einer Sichtfreigabe.
 
+Sichtfreigaben für einen Personenkontext können nur durch die Organisation erstellt, aufgelistet oder gelöscht werden, denen der Personenkontext zugeordnet ist (Attribut `personenkontext.organisation`). 
+
 Attribut | Typ | Anzahl | Bemerkung
 --- | --- | --- | ---
 id | String (UTF-8) | 1 | ID der Sichtfreigabe.

--- a/docs/datenmodell-qs/sichtfreigabe.md
+++ b/docs/datenmodell-qs/sichtfreigabe.md
@@ -4,7 +4,7 @@ tags:
 ---
 # Sichtfreigabe
 
-Sichtfreigaben für einen Personenkontext können nur durch die Organisation erstellt, aufgelistet oder gelöscht werden, welcher der Personenkontext zugeordnet ist (Attribut `personenkontext.organisation`). 
+Sichtfreigaben für einen Personenkontext können durch die Organisation erstellt, aufgelistet oder gelöscht werden, welcher der Personenkontext zugeordnet ist (Attribut `personenkontext.organisation`). 
 
 Diese Organisation kann einer anderen Organisation (spezifiziert durch das Attribut `orgid`) eine Sichtfreigabe erteilen, welche der zweiten Organisation ermöglicht lesend auf diesen Personenkontext und den dazugehörigen Datensatz `person` zuzugreifen.
 

--- a/docs/datenmodell-qs/sichtfreigabe.md
+++ b/docs/datenmodell-qs/sichtfreigabe.md
@@ -4,9 +4,13 @@ tags:
 ---
 # Sichtfreigabe
 
-Datenmodell einer Sichtfreigabe.
+Sichtfreigaben für einen Personenkontext können nur durch die Organisation erstellt, aufgelistet oder gelöscht werden, welcher der Personenkontext zugeordnet ist (Attribut `personenkontext.organisation`). 
 
-Sichtfreigaben für einen Personenkontext können nur durch die Organisation erstellt, aufgelistet oder gelöscht werden, denen der Personenkontext zugeordnet ist (Attribut `personenkontext.organisation`). 
+Diese Organisation kann einer anderen Organisation (spezifiziert durch das Attribut `orgid`) eine Sichtfreigabe erteilen, welche der zweiten Organisation ermöglicht lesend auf diesen Personenkontext und den dazugehörigen Datensatz `person` zuzugreifen.
+
+Ein solcher Zugriff kann über die Attribute `von` und `bis` zeitlich begrenzt werden. 
+
+Unabhängig von dieser zeitlichen Begrenzung kann eine Sichtfreigabe jederzeit durch die DELETE API für Sichtfreigabe gelöscht werden. Dabei sind sowohl die Organisation, welche die Sichtfreigabe erteilt hat, als auch die zweite Organisation, für welche die Sichtfreigabe erteilt wurde, berechtigt diese Sichtfreigabe zu löschen.
 
 Attribut | Typ | Anzahl | Bemerkung
 --- | --- | --- | ---

--- a/src/openapi/paths-personenkontexte-id-sichtfreigaben.yaml
+++ b/src/openapi/paths-personenkontexte-id-sichtfreigaben.yaml
@@ -13,6 +13,9 @@ post:
     Einsicht freigegeben werden. Dabei kann die andere Organisation auf diese freigegebenen Daten
     nur lesend zugreifen. Das Erstellen oder Ändern der Daten durch die andere Organisation ist nicht zulässig oder möglich.
 
+    Eine Sichtfreigabe für einen Personenkontext kann nur durch die Organisation erfolgen, der ein Personenkontext zugeordnet ist
+    (Attribut `personenkontext.organisation`). 
+
     Sichtfreigaben können nur für Personenkontexte erteilt werden. Dabei ist über die API immer nur die Sichtfreigabe
     einzelner Personenkontexte möglich. Es besteht nicht die Möglichkeit, über die API alle Personenkontexte einer
     Organisation pauschal einer anderen Organisation bereit zu stellen.
@@ -92,6 +95,8 @@ get:
   description: |
    Dieser Schnittstellenendpunkt gibt eine Liste der existierenden Sichtfreigaben eines
    Personenkontexts zurück.
+   
+   Es werden nur Sichtfreigaben für einen Personenkontexte zurückgegeben, welche der abfragenden Organisation zugeordnet sind (Attribut `personenkontext.organisation`). 
 
    Ein READ zum Abfragen der Sichtfreigaben per `personenkontext.id` muss mit HTTP-GET auf die API `/personenkontexte/{personenkontext.id}/sichtfreigaben` erfolgen.
 

--- a/src/openapi/paths-personenkontexte-id-sichtfreigaben.yaml
+++ b/src/openapi/paths-personenkontexte-id-sichtfreigaben.yaml
@@ -13,7 +13,7 @@ post:
     Einsicht freigegeben werden. Dabei kann die andere Organisation auf diese freigegebenen Daten
     nur lesend zugreifen. Das Erstellen oder Ändern der Daten durch die andere Organisation ist nicht zulässig oder möglich.
 
-    Eine Sichtfreigabe für einen Personenkontext kann nur durch die Organisation erfolgen, der ein Personenkontext zugeordnet ist
+    Eine Sichtfreigabe für einen Personenkontext kann nur durch die Organisation erstellt werden, welcher der Personenkontext zugeordnet ist
     (Attribut `personenkontext.organisation`). 
 
     Sichtfreigaben können nur für Personenkontexte erteilt werden. Dabei ist über die API immer nur die Sichtfreigabe

--- a/src/openapi/paths-personenkontexte-id-sichtfreigaben.yaml
+++ b/src/openapi/paths-personenkontexte-id-sichtfreigaben.yaml
@@ -96,7 +96,9 @@ get:
    Dieser Schnittstellenendpunkt gibt eine Liste der existierenden Sichtfreigaben eines
    Personenkontexts zurück.
    
-   Es werden nur Sichtfreigaben für einen Personenkontexte zurückgegeben, welche der abfragenden Organisation zugeordnet sind (Attribut `personenkontext.organisation`). 
+   Es werden sowohl die Sichtfreigaben für einen Personenkontext zurückgegeben, welcher der abfragenden Organisation
+   zugeordnet sind (Attribut `personenkontext.organisation`), als auch für einen Personenkontext, für den
+   einer Organisation eine Sichtfreigabe erteilt wurde. 
 
    Ein READ zum Abfragen der Sichtfreigaben per `personenkontext.id` muss mit HTTP-GET auf die API `/personenkontexte/{personenkontext.id}/sichtfreigaben` erfolgen.
 

--- a/src/openapi/paths-sichtfreigaben-id.yaml
+++ b/src/openapi/paths-sichtfreigaben-id.yaml
@@ -14,6 +14,8 @@ delete:
 
     Im Normalfall wird eine Sichtfreigabe über das in ihr enthaltene Enddatum terminiert.
 
+    Eine Löschung kann nur durch die Organisation erfolgen, welche die Sichtfreigabe angelegt hat.
+    
     Ein DELETE muss mit einer HTTP-DELETE Anfrage erfolgen. Die Anfrage-Nutzdaten (Request Payload)
     beinhalten die Revisionsnummer.
 

--- a/src/openapi/paths-sichtfreigaben-id.yaml
+++ b/src/openapi/paths-sichtfreigaben-id.yaml
@@ -14,7 +14,7 @@ delete:
 
     Im Normalfall wird eine Sichtfreigabe über das in ihr enthaltene Enddatum terminiert.
 
-    Eine Löschung kann sowohl durch die Organisation erfolgen, welche die Sichtfreigabe angelegt hat, als auch durch die Organisation, welche die Sichtfreigabe erhalten hat.
+    Eine Löschung kann sowohl durch die Organisation erfolgen, welche die Sichtfreigabe erstellt hat, als auch durch die Organisation, welche die Sichtfreigabe erhalten hat.
     
     Ein DELETE muss mit einer HTTP-DELETE Anfrage erfolgen. Die Anfrage-Nutzdaten (Request Payload)
     beinhalten die Revisionsnummer.

--- a/src/openapi/paths-sichtfreigaben-id.yaml
+++ b/src/openapi/paths-sichtfreigaben-id.yaml
@@ -14,7 +14,7 @@ delete:
 
     Im Normalfall wird eine Sichtfreigabe über das in ihr enthaltene Enddatum terminiert.
 
-    Eine Löschung kann nur durch die Organisation erfolgen, welche die Sichtfreigabe angelegt hat.
+    Eine Löschung kann sowohl durch die Organisation erfolgen, welche die Sichtfreigabe angelegt hat, als auch durch die Organisation, welche die Sichtfreigabe erhalten hat.
     
     Ein DELETE muss mit einer HTTP-DELETE Anfrage erfolgen. Die Anfrage-Nutzdaten (Request Payload)
     beinhalten die Revisionsnummer.


### PR DESCRIPTION
Klarstellung im OpenAPI Text und beim Sichtfreigabe Datenmodell, dass die Funktionen auf Sichtfreigabe (Erstellen, Auflisten, Löschen) nur für die Organisation zulässig sind, denen der Personenkontext zugeordnet ist.

Vor einem Merge wäre noch zu klären, ob das so beabsichtigt ist (dass nur die im Personenkontext genannte Organisation Zugriff hat) oder ob statt dessen das Recht eher beim Mandanten (als formaler Eigner des Datensatzes) liegen sollte.

Wenn das mir der Organisation passt, dann kann ein Merge erfolgen, sonst muss der Text noch mal überarbeitet werden.

