### PR TITLE
#499 Filter organisation.id für GET /personen und GET /personenkontexte

### DIFF
--- a/src/openapi/paths-gruppen.yaml
+++ b/src/openapi/paths-gruppen.yaml
@@ -73,8 +73,7 @@ get:
     - oAuthForServices: []
   summary: Gruppendatensätzen des Quellsystemanbieters
   description: |
-    Dieser Schnittstellenendpunkt gibt ein Array von Gruppendatensätzen zurück, die vom
-    Anfrager ausgelesen werden dürfen.
+    Dieser Schnittstellenendpunkt gibt ein Array von Gruppendatensätzen zurück, auf die das Quellsystem zugreifen darf.
 
     Ein READ muss mit einer HTTP-GET Anfrage erfolgen. Die Antwort-Nutzdaten (Response
     Payload) beinhalten ein Array von JSON-Objekten vom Datentyp Gruppendatensatz, sofern

--- a/src/openapi/paths-gruppenzugehoerigkeiten.yaml
+++ b/src/openapi/paths-gruppenzugehoerigkeiten.yaml
@@ -7,7 +7,7 @@ get:
   summary: Auflistung aller Gruppenzugehörigkeiten
   description: |
     Dieser Schnittstellenendpunkt gibt alle Gruppenzugehörigkeiten zurück, auf die
-    der Quellsystemanbieter zugreifen kann.
+    das Quellsystem zugreifen kann.
 
     Ein READ muss mit einer HTTP-GET Anfrage erfolgen. Die Antwort-Nutzdaten
     (Response Payload) beinhalten ein Array von JSON-Objekten vom Datentyp Gruppendatensatz

--- a/src/openapi/paths-gruppenzugehoerigkeiten.yaml
+++ b/src/openapi/paths-gruppenzugehoerigkeiten.yaml
@@ -7,7 +7,7 @@ get:
   summary: Auflistung aller Gruppenzugehörigkeiten
   description: |
     Dieser Schnittstellenendpunkt gibt alle Gruppenzugehörigkeiten zurück, auf die
-    das Quellsystem zugreifen kann.
+    das Quellsystem zugreifen darf.
 
     Ein READ muss mit einer HTTP-GET Anfrage erfolgen. Die Antwort-Nutzdaten
     (Response Payload) beinhalten ein Array von JSON-Objekten vom Datentyp Gruppendatensatz

--- a/src/openapi/paths-personen-info.yaml
+++ b/src/openapi/paths-personen-info.yaml
@@ -63,7 +63,8 @@ get:
     `pid` | String || Mit diesem Filter kann der Datensatz einer einzelnen Person anhand ihrer `pid` ausgelesen werden.
     `personenkontext.id` | String || Mit diesem Filter kann der Datensatz einer einzelnen Person mit einem einzelnen Personenkontext anhand der Kontext-ID ausgelesen werden. Die Informationen zur entsprechenden Person werden, unter Berücksichtigung des Filters `vollstaendig`, entsprechend der Client-Berechtigungen ausgeliefert.
     `gruppe.id` | String || Mit diesem Filter können die Datensätze aller Personen ausgegeben werden, welche einer Gruppe zugeordnet sind. Die Informationen zur entsprechenden Person werden, unter Berücksichtigung des Filters `vollstaendig`, entsprechend der Client-Berechtigungen ausgeliefert. Es ist abhängig vom Schulconnex-Server, ob alle existierenden Personen der Gruppe mit aufgeführt werden oder nur solche, welche schon von dem Dienst abgerufen wurden und damit dem Dienst bekannt sind.
-    `organisation.id` | String || Mit diesem Filter können die Datensätze aller Personen ausgegeben werden, welche einer Organisation zugeordnet sind. Die Informationen zur entsprechenden Person werden, unter Berücksichtigung des Filters `vollstaendig`, entsprechend der Client-Berechtigungen ausgeliefert. Es ist abhängig vom Schulconnex-Server, ob alle existierenden Personen einer Organisation mit aufgeführt werden oder nur solche, welche schon von dem Dienst abgerufen wurden und damit dem Dienst bekannt sind.
+    `stammorganisation.id` | String || Mit diesem Filter können die Datensätze aller Personen ausgegeben werden, welche einer Stammorganisation zugeordnet sind. 
+    `organisation.id` | String || Mit diesem Filter können die Datensätze aller Personen ausgegeben werden, welche mindestens einen Personenkontext besitzen, welche der Organisation zugeordnet ist. Die Informationen zur entsprechenden Person werden, unter Berücksichtigung des Filters `vollstaendig`, entsprechend der Client-Berechtigungen ausgeliefert. Es ist abhängig vom Schulconnex-Server, ob alle existierenden Personen einer Organisation mit aufgeführt werden oder nur solche, welche schon von dem Dienst abgerufen wurden und damit dem Dienst bekannt sind.
   parameters:
     - in: query
       name: vollstaendig
@@ -89,6 +90,10 @@ get:
         type: string
     - in: query
       name: gruppe.id
+      schema:
+        type: string
+    - in: query
+      name: stammorganisation.id
       schema:
         type: string
     - in: query

--- a/src/openapi/paths-personen.yaml
+++ b/src/openapi/paths-personen.yaml
@@ -22,7 +22,8 @@ get:
     --- | --- | ---
     `referrer` | String | Möglichkeit, die Ergebnisliste der Anfrage nach dem Fremdschlüssel `referrer` zu filtern. Der Schulconnex-Server überprüft, ob der Wert des Filterparameters ohne Beachtung von Groß- und Kleinschreibung im Filter-Attribut beinhaltet ist (contains).
     `mandant` | String | Möglichkeit, die Ergebnisliste der Anfrage nach dem Attribut `mandant` zu filtern. Der Schulconnex-Server überprüft, ob der Wert des Filterparameters unabhängig von Groß- und Kleinschreibung im Filter-Attribut beinhaltet ist (contains).
-    `organisation.id` | String | Mit diesem Filter können die Datensätze aller Personen ausgegeben werden, welche einer Organisation zugeordnet sind. 
+    `stammorganisation` | String | Mit diesem Filter können die Datensätze aller Personen ausgegeben werden, welche einer Stammorganisation zugeordnet sind. 
+    `organisation.id` | String | Mit diesem Filter können Datensätze der Personen ausgegeben werden, welche mindestens einen Personenkontext besitzen, welche der Organisation zugeordnet ist. Nur die Daten zur Person und die Personenkontexte mit der angegeben Organisations-ID werden geliefert. 
     `familienname` | String | Möglichkeit, die Ergebnisliste der Anfrage nach dem Attribut `person.name.familienname` zu filtern. Der Schulconnex-Server überprüft, ob der Wert des Filter-parameters ohne Beachtung von Groß- und Kleinschreibung im Filter-Attribut beinhaltet ist (contains).
     `vorname` | String | Möglichkeit, die Ergebnisliste der Anfrage nach dem Attribut `person.name.vorname` zu filtern. Der Schulconnex-Server überprüft, ob der Wert des Filter-parameters ohne Beachtung von Groß- und Kleinschreibung im Filter-Attribut beinhaltet ist (contains).
     `sichtfreigabe` | String | Erlaubt es Personen, abhängig davon aufzulisten, ob diese von einer anderen Organisation zum Lesen freigegeben wurden. Die möglichen Optionen sind `sichtfreigabe=ja`, um nur die durch externe Organisationen freigegebenen Personen beziehungsweise Personenkontexte aufzulisten und `sichtfreigabe=nein`, um nur eigene Personen beziehungsweise Personenkontexte aufzulisten. Wird nicht nach Sichtfreigabe gefiltert, so werden alle lesbaren Personen, beziehungsweise Personenkontexte geliefert.
@@ -45,6 +46,10 @@ get:
         type: string
     - in: query
       name: mandant
+      schema:
+        type: string
+    - in: query
+      name: stammorganisation
       schema:
         type: string
     - in: query

--- a/src/openapi/paths-personen.yaml
+++ b/src/openapi/paths-personen.yaml
@@ -7,7 +7,7 @@ get:
   summary: Personendatensätze des Quellsystemanbieters
   description: |
     Mittels dieses Endpunkts werden alle Personendatensätze zurückgegeben, auf die
-    der Quellsystemanbieter zugreifen darf.
+    das Quellsystem zugreifen darf.
 
     Ein READ muss mit einer HTTP-GET Anfrage erfolgen.
     Die Schnittstelle `/personen` ermöglicht das Verwenden von Filterparametern zur

--- a/src/openapi/paths-personen.yaml
+++ b/src/openapi/paths-personen.yaml
@@ -22,6 +22,7 @@ get:
     --- | --- | ---
     `referrer` | String | Möglichkeit, die Ergebnisliste der Anfrage nach dem Fremdschlüssel `referrer` zu filtern. Der Schulconnex-Server überprüft, ob der Wert des Filterparameters ohne Beachtung von Groß- und Kleinschreibung im Filter-Attribut beinhaltet ist (contains).
     `mandant` | String | Möglichkeit, die Ergebnisliste der Anfrage nach dem Attribut `mandant` zu filtern. Der Schulconnex-Server überprüft, ob der Wert des Filterparameters unabhängig von Groß- und Kleinschreibung im Filter-Attribut beinhaltet ist (contains).
+    `organisation.id` | String | Mit diesem Filter können die Datensätze aller Personen ausgegeben werden, welche einer Organisation zugeordnet sind. 
     `familienname` | String | Möglichkeit, die Ergebnisliste der Anfrage nach dem Attribut `person.name.familienname` zu filtern. Der Schulconnex-Server überprüft, ob der Wert des Filter-parameters ohne Beachtung von Groß- und Kleinschreibung im Filter-Attribut beinhaltet ist (contains).
     `vorname` | String | Möglichkeit, die Ergebnisliste der Anfrage nach dem Attribut `person.name.vorname` zu filtern. Der Schulconnex-Server überprüft, ob der Wert des Filter-parameters ohne Beachtung von Groß- und Kleinschreibung im Filter-Attribut beinhaltet ist (contains).
     `sichtfreigabe` | String | Erlaubt es Personen, abhängig davon aufzulisten, ob diese von einer anderen Organisation zum Lesen freigegeben wurden. Die möglichen Optionen sind `sichtfreigabe=ja`, um nur die durch externe Organisationen freigegebenen Personen beziehungsweise Personenkontexte aufzulisten und `sichtfreigabe=nein`, um nur eigene Personen beziehungsweise Personenkontexte aufzulisten. Wird nicht nach Sichtfreigabe gefiltert, so werden alle lesbaren Personen, beziehungsweise Personenkontexte geliefert.
@@ -44,6 +45,10 @@ get:
         type: string
     - in: query
       name: mandant
+      schema:
+        type: string
+    - in: query
+      name: organisation.id
       schema:
         type: string
     - in: query

--- a/src/openapi/paths-personenkontexte.yaml
+++ b/src/openapi/paths-personenkontexte.yaml
@@ -7,7 +7,7 @@ get:
   summary: Auflistung von Personenkontexten
   description: |
     Die Schnittstelle `/personenkontexte` bezieht sich auf das Anfordern und die
-    Auflistung von Personenkontexten auf die das Quellsystem zugreifen darf.
+    Auflistung von Personenkontexten, auf die das Quellsystem zugreifen darf.
 
     Die Schnittstelle `/personenkontexte` ermöglicht das Verwenden von Filterparametern
     zur Präzisierung der Anfrage bei HTTP-GET. Werden mehrere Filter angegeben, so sind

--- a/src/openapi/paths-personenkontexte.yaml
+++ b/src/openapi/paths-personenkontexte.yaml
@@ -19,7 +19,8 @@ get:
     --- | --- | ---
     `referrer` | String | Möglichkeit, die Ergebnisliste der Anfrage nach dem Fremdschlüssel `referrer` zu filtern. Der Schulconnex-Server überprüft, ob der Wert des Filterparameters ohne Beachtung von Groß- und Kleinschreibung im Filter-Attribut beinhaltet ist (contains).
     `mandant` | String | Möglichkeit, die Ergebnisliste der Anfrage nach dem Attribut `mandant` zu filtern. Der Schulconnex-Server überprüft, ob der Wert des Filterparameters unabhängig von Groß- und Kleinschreibung im Filter-Attribut beinhaltet ist (contains).
-    `organisation.id` | String | Mit diesem Filter können die Datensätze aller Personen ausgegeben werden, welche einer Organisation zugeordnet sind. 
+    `stammorganisation` | String | Mit diesem Filter können die Datensätze aller Personen ausgegeben werden, welche einer Stammorganisation zugeordnet sind. 
+    `organisation.id` | String | Mit diesem Filter können Datensätze der Personen ausgegeben werden, welche mindestens einen Personenkontext besitzen, welche der Organisation zugeordnet ist. Nur die Daten zur Person und die Personenkontexte mit der angegeben Organisations-ID werden geliefert. 
     `rolle` | String (Code) | Möglichkeit, die Ergebnisliste der Anfrage nach dem Attribut `personenkontext.rolle` zu filtern. Der Schulconnex-Server überprüft, ob der Wert des Filterparameters mit dem Wert des Filter-Attributs übereinstimmt (equals). Dem Filterparameter liegt eine Codeliste [Rolle](../../../codelisten#rolle) zugrunde.
     `personenstatus` | String (Code) | Möglichkeit, die Ergebnisliste der Anfrage nach dem Attribut „personenkontext.personenstatus” zu filtern. Der Schulconnex-Server überprüft, ob der Wert des Filterparameters mit dem Wert des Filter-Attributs übereinstimmt (equals). Dem Filterparameter liegt die Codeliste [Personenstatus](../../../codelisten#personenstatus) zugrunde.
     `sichtfreigabe` | String | Erlaubt es Personen, abhängig davon aufzulisten, ob diese von einer anderen Organisation zum Lesen freigegeben wurden. Die möglichen Optionen sind `sichtfreigabe=ja`, um nur die durch externe Organisationen freigegebenen Personen beziehungsweise Personenkontexte aufzulisten, und `sichtfreigabe=nein`, um nur eigene Personen beziehungsweise Personenkontexte aufzulisten. Wird nicht nach Sichtfreigabe gefiltert, so werden alle lesbaren Personen, beziehungsweise Personenkontexte geliefert.
@@ -50,6 +51,10 @@ get:
         type: string
     - in: query
       name: mandant
+      schema:
+        type: string
+    - in: query
+      name: stammorganisation
       schema:
         type: string
     - in: query

--- a/src/openapi/paths-personenkontexte.yaml
+++ b/src/openapi/paths-personenkontexte.yaml
@@ -7,7 +7,7 @@ get:
   summary: Auflistung von Personenkontexten
   description: |
     Die Schnittstelle `/personenkontexte` bezieht sich auf das Anfordern und die
-    Auflistung von Personenkontexten in Bezug zu der eigenen Organisation.
+    Auflistung von Personenkontexten auf die das Quellsystem zugreifen darf.
 
     Die Schnittstelle `/personenkontexte` ermöglicht das Verwenden von Filterparametern
     zur Präzisierung der Anfrage bei HTTP-GET. Werden mehrere Filter angegeben, so sind

--- a/src/openapi/paths-personenkontexte.yaml
+++ b/src/openapi/paths-personenkontexte.yaml
@@ -19,6 +19,7 @@ get:
     --- | --- | ---
     `referrer` | String | Möglichkeit, die Ergebnisliste der Anfrage nach dem Fremdschlüssel `referrer` zu filtern. Der Schulconnex-Server überprüft, ob der Wert des Filterparameters ohne Beachtung von Groß- und Kleinschreibung im Filter-Attribut beinhaltet ist (contains).
     `mandant` | String | Möglichkeit, die Ergebnisliste der Anfrage nach dem Attribut `mandant` zu filtern. Der Schulconnex-Server überprüft, ob der Wert des Filterparameters unabhängig von Groß- und Kleinschreibung im Filter-Attribut beinhaltet ist (contains).
+    `organisation.id` | String | Mit diesem Filter können die Datensätze aller Personen ausgegeben werden, welche einer Organisation zugeordnet sind. 
     `rolle` | String (Code) | Möglichkeit, die Ergebnisliste der Anfrage nach dem Attribut `personenkontext.rolle` zu filtern. Der Schulconnex-Server überprüft, ob der Wert des Filterparameters mit dem Wert des Filter-Attributs übereinstimmt (equals). Dem Filterparameter liegt eine Codeliste [Rolle](../../../codelisten#rolle) zugrunde.
     `personenstatus` | String (Code) | Möglichkeit, die Ergebnisliste der Anfrage nach dem Attribut „personenkontext.personenstatus” zu filtern. Der Schulconnex-Server überprüft, ob der Wert des Filterparameters mit dem Wert des Filter-Attributs übereinstimmt (equals). Dem Filterparameter liegt die Codeliste [Personenstatus](../../../codelisten#personenstatus) zugrunde.
     `sichtfreigabe` | String | Erlaubt es Personen, abhängig davon aufzulisten, ob diese von einer anderen Organisation zum Lesen freigegeben wurden. Die möglichen Optionen sind `sichtfreigabe=ja`, um nur die durch externe Organisationen freigegebenen Personen beziehungsweise Personenkontexte aufzulisten, und `sichtfreigabe=nein`, um nur eigene Personen beziehungsweise Personenkontexte aufzulisten. Wird nicht nach Sichtfreigabe gefiltert, so werden alle lesbaren Personen, beziehungsweise Personenkontexte geliefert.
@@ -49,6 +50,10 @@ get:
         type: string
     - in: query
       name: mandant
+      schema:
+        type: string
+    - in: query
+      name: organisation.id
       schema:
         type: string
     - in: query


### PR DESCRIPTION
Die entsprechenden Filter sind eingebaut.

Eventuell sollte aber noch hinzugefügt werden, in welchen Fällen die Funktion sinnvoll ist, da beispielsweise gilt: "Die Schnittstelle /personenkontexte bezieht sich auf das Anfordern und die Auflistung von Personenkontexten in Bezug zu der eigenen Organisation."

Da ohnehin nur die Personenkontexte zur eigenen Organisation geliefert werden, ist der Filter nur in wenigen Spezialfällen sinnvoll.