### PR TITLE
#496 GitHub generierte Sitemap fehlerhaft

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -8,7 +8,7 @@ const config: Config = {
   favicon: 'img/favicon.ico',
 
   // Set the production url of your site here
-  url: 'https://schulconnex.github.io',
+  url: 'https://schulconnex.de',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: '/',


### PR DESCRIPTION
Als Production Server sollte schulconnex.de statt schulconnex.github.io gesetzt sein. 
Dann passt auch sitemap.xml zur Schulconnex-Webseite.