### PR TITLE
#502 UI-Toggle für qualifizierte Namen

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -1,6 +1,9 @@
 import { themes as prismThemes } from 'prism-react-renderer';
 import type { Config } from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
 
 const config: Config = {
   title: 'Schulconnex',
@@ -8,7 +11,7 @@ const config: Config = {
   favicon: 'img/favicon.ico',
 
   // Set the production url of your site here
-  url: 'https://schulconnex.de',
+  url: 'https://schulconnex.github.io',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: '/',
@@ -30,6 +33,9 @@ const config: Config = {
 
   markdown: {
     mermaid: true,
+    hooks: {
+      onBrokenMarkdownLinks: 'throw',
+    },
     remarkRehypeOptions: {
       footnoteLabel: 'Fußnoten',
     },
@@ -260,6 +266,21 @@ const config: Config = {
         }
       },
     ]
+    ,
+    function webpackNodePolyfills() {
+      return {
+        name: 'webpack-node-polyfills',
+        configureWebpack() {
+          return {
+            resolve: {
+              fallback: {
+                path: require.resolve('path-browserify'),
+              },
+            },
+          };
+        },
+      };
+    }
   ],
 };
 

--- a/package.json
+++ b/package.json
@@ -18,13 +18,15 @@
     "write-dereferenced-openapi-for-dienste": "redocly bundle --dereferenced --remove-unused-components src/openapi/api-dienste.yaml | node util/resolve-relative-urls.js > static/dist/openapi/api-dienste.yaml",
     "write-dereferenced-openapi-for-policies": "redocly bundle --dereferenced --remove-unused-components src/openapi/api-policies.yaml | node util/resolve-relative-urls.js > static/dist/openapi/api-nutzungsrechte.yaml",
     "write-dereferenced-openapi": "npm run write-dereferenced-openapi-for-dienste && npm run write-dereferenced-openapi-for-qs && npm run write-dereferenced-openapi-for-policies",
-    "validate-openapi": "npx @redocly/cli lint src/openapi/api-dienste.yaml src/openapi/api-qs.yaml"
+    "validate-openapi": "npx @redocly/cli lint src/openapi/api-dienste.yaml src/openapi/api-qs.yaml",
+    "audit:qualified-names": "node util/audit-qualified-names.mjs"
   },
   "dependencies": {
     "@docusaurus/core": "^3.8.1",
     "@docusaurus/preset-classic": "^3.8.1",
     "@docusaurus/theme-mermaid": "^3.8.1",
     "@mdx-js/react": "^3.0.0",
+    "ajv": "^8.17.1",
     "clsx": "^2.0.0",
     "docusaurus-plugin-openapi-docs": "^4.5.1",
     "docusaurus-theme-openapi-docs": "^4.5.1",
@@ -38,6 +40,7 @@
     "@docusaurus/tsconfig": "^3.8.1",
     "@docusaurus/types": "^3.8.1",
     "@redocly/cli": "^2.1.0",
+    "path-browserify": "^1.0.1",
     "prettier": "^3.2.5",
     "typescript": "~5.2.2"
   },

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -136,3 +136,51 @@ code[class*='codeBlockLinesWithNumbering'] > .theme-code-block-highlighted-line 
 .tag-cl-generisch { background: var(--ifm-color-danger-contrast-background); color: var(--ifm-color-danger-contrast-foreground); }
 .tag-cl-lokal { background: var(--ifm-color-success-contrast-background); color: var(--ifm-color-success-contrast-foreground); }
 .tag-cl-system  { background: var(--ifm-color-warning-contrast-background); color: var(--ifm-color-warning-contrast-foreground);  }
+/* Tabellen in Docs: besser lesbar bei vielen Spalten (z.B. "Qualifizierter Name"). */
+.theme-doc-markdown table {
+  display: block;
+  max-width: 100%;
+  overflow-x: auto;
+  font-size: 0.95em;
+}
+
+.theme-doc-markdown table th,
+.theme-doc-markdown table td {
+  vertical-align: top;
+}
+
+/* Lange URNs/Inline-Code in Tabellen sollen sauber umbrechen können. */
+.theme-doc-markdown table td code,
+.theme-doc-markdown table th code {
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+/* Toggle: Qualifizierter Name Spalte ein-/ausblenden */
+.qualified-names-table .qualified-name-col {
+  display: none;
+}
+
+html.show-qualified-names .qualified-names-table .qualified-name-col {
+  display: table-cell;
+}
+
+.qualified-names-toggle {
+  display: flex;
+  align-items: center;
+  gap: var(--ifm-spacing-horizontal);
+  margin: 0 0 var(--ifm-spacing-vertical);
+  padding: var(--ifm-spacing-vertical) var(--ifm-spacing-horizontal);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: var(--ifm-alert-border-radius);
+}
+
+.qualified-names-toggle input[type='checkbox'] {
+  margin: 0;
+}
+
+.qualified-names-toggle label {
+  margin: 0;
+  cursor: pointer;
+}

--- a/src/theme/Root.tsx
+++ b/src/theme/Root.tsx
@@ -1,0 +1,138 @@
+import React, { useEffect } from 'react';
+import Root from '@theme-original/Root';
+import type { Props } from '@theme/Root';
+import { useLocation } from '@docusaurus/router';
+
+const STORAGE_KEY = 'schulconnex.showQualifiedNames';
+const HTML_CLASS = 'show-qualified-names';
+const TOGGLE_ID = 'qualified-names-toggle';
+const CHECKBOX_ID = 'qualified-names-toggle-checkbox';
+
+function readStoredPreference(): boolean {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (raw === null) return false;
+    return raw === 'true';
+  } catch {
+    return false;
+  }
+}
+
+function writeStoredPreference(value: boolean) {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, String(value));
+  } catch {
+    // ignore
+  }
+}
+
+function setEnabled(enabled: boolean) {
+  document.documentElement.classList.toggle(HTML_CLASS, enabled);
+}
+
+function normalizeHeaderText(text: string): string {
+  return text.replace(/\s+/g, ' ').trim();
+}
+
+function annotateQualifiedNameTables(): boolean {
+  const tables = Array.from(document.querySelectorAll<HTMLTableElement>('.theme-doc-markdown table'));
+  let found = false;
+
+  for (const table of tables) {
+    const headers = Array.from(table.querySelectorAll<HTMLTableCellElement>('thead th'));
+    if (headers.length === 0) continue;
+
+    const headerIndex = headers.findIndex((th) => {
+      const label = normalizeHeaderText(th.textContent ?? '');
+      return label === 'Qualifizierter Name';
+    });
+
+    if (headerIndex === -1) continue;
+
+    found = true;
+    table.classList.add('qualified-names-table');
+
+    const rows = Array.from(table.querySelectorAll<HTMLTableRowElement>('tr'));
+    for (const row of rows) {
+      const cells = Array.from(row.children).filter((el) => {
+        const tag = el.tagName.toLowerCase();
+        return tag === 'td' || tag === 'th';
+      }) as Array<HTMLTableCellElement>;
+
+      const cell = cells[headerIndex];
+      if (cell) {
+        cell.classList.add('qualified-name-col');
+      }
+    }
+  }
+
+  return found;
+}
+
+function ensureToggleVisible(shouldShow: boolean) {
+  const container = document.querySelector<HTMLElement>('.theme-doc-markdown');
+  if (!container) return;
+
+  const existing = document.getElementById(TOGGLE_ID);
+  if (!shouldShow) {
+    existing?.remove();
+    return;
+  }
+
+  if (existing) return;
+
+  const wrapper = document.createElement('div');
+  wrapper.id = TOGGLE_ID;
+  wrapper.className = 'qualified-names-toggle';
+
+  const checkbox = document.createElement('input');
+  checkbox.type = 'checkbox';
+  checkbox.id = CHECKBOX_ID;
+
+  const label = document.createElement('label');
+  label.htmlFor = CHECKBOX_ID;
+  label.textContent = 'Qualifizierte Namen anzeigen';
+
+  wrapper.appendChild(checkbox);
+  wrapper.appendChild(label);
+
+  container.prepend(wrapper);
+
+  const apply = (value: boolean) => {
+    setEnabled(value);
+    checkbox.checked = value;
+    writeStoredPreference(value);
+  };
+
+  const initial = readStoredPreference();
+  apply(initial);
+
+  checkbox.addEventListener('change', () => {
+    apply(checkbox.checked);
+  });
+}
+
+export default function RootWrapper(props: Props) {
+  const location = useLocation();
+
+  useEffect(() => {
+    // Apply preference early on each route change.
+    setEnabled(readStoredPreference());
+
+    // Annotate and wire toggle after DOM updates.
+    // Run twice to be resilient against async content rendering.
+    const run = () => {
+      const hasTables = annotateQualifiedNameTables();
+      ensureToggleVisible(hasTables);
+    };
+
+    run();
+    const t = window.setTimeout(run, 50);
+
+    return () => {
+      window.clearTimeout(t);
+    };
+  }, [location.pathname]);
+
+  return <Root {...props} />;
+}

--- a/util/audit-qualified-names.mjs
+++ b/util/audit-qualified-names.mjs
@@ -1,0 +1,183 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const WORKDIR = process.cwd();
+
+const SCAN_DIRS = [
+  path.join(WORKDIR, 'docs', 'datenmodell-qs'),
+  path.join(WORKDIR, 'docs', 'datenmodell-dienste'),
+];
+
+const URN_CODE_SPAN_REGEX = /`(urn:[^`\s]+)`/g;
+
+function isMarkdownFile(filePath) {
+  return filePath.toLowerCase().endsWith('.md') || filePath.toLowerCase().endsWith('.mdx');
+}
+
+async function* walk(dirPath) {
+  const entries = await fs.readdir(dirPath, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(dirPath, entry.name);
+    if (entry.isDirectory()) {
+      yield* walk(fullPath);
+    } else {
+      yield fullPath;
+    }
+  }
+}
+
+function isUrnRfc8141ish(urn) {
+  // RFC 8141 (very lightweight syntactic checks)
+  // URN = "urn:" NID ":" NSS
+  // NID: 2..32 chars, [a-z0-9][a-z0-9-]{0,31}
+  // NSS: we check it is non-empty and uses only common ASCII URN-safe characters.
+  const match = /^urn:([a-z0-9][a-z0-9-]{1,31}):(.+)$/i.exec(urn);
+  if (!match) return { ok: false, reason: 'not urn:NID:NSS' };
+
+  const nid = match[1];
+  const nss = match[2];
+
+  if (nid.length < 2 || nid.length > 32) {
+    return { ok: false, reason: 'NID length invalid' };
+  }
+
+  // Conservative NSS character check (ASCII, no spaces, no backticks).
+  // Allow unreserved / pct-encoded / sub-delims / ":" / "@" / "/".
+  // unreserved = ALPHA / DIGIT / "-" / "." / "_" / "~"
+  // sub-delims = "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "="
+  // pchar = unreserved / pct-encoded / sub-delims / ":" / "@"
+  // plus "/".
+  const nssOk = /^[A-Za-z0-9\-._~%!$&'()*+,;=:@/]+$/.test(nss);
+  if (!nssOk) return { ok: false, reason: 'NSS contains unexpected characters' };
+
+  return { ok: true };
+}
+
+function tryExtractTableContext(line) {
+  // Best-effort: for markdown tables, attribute is first cell.
+  // "a | b | c | `urn:...`" => attribute "a".
+  if (!line.includes('|')) return null;
+  const parts = line.split('|').map((p) => p.trim());
+  if (parts.length < 3) return null;
+  const attribute = parts[0];
+  const type = parts[1] ?? '';
+  return { attribute, type };
+}
+
+function rel(p) {
+  return path.relative(WORKDIR, p).split(path.sep).join('/');
+}
+
+async function main() {
+  const occurrences = [];
+
+  for (const dir of SCAN_DIRS) {
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      for await (const filePath of walk(dir)) {
+        if (!isMarkdownFile(filePath)) continue;
+        const content = await fs.readFile(filePath, 'utf8');
+        const lines = content.split(/\r?\n/);
+
+        for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
+          const line = lines[lineIndex];
+          if (!line.includes('`urn:')) continue;
+
+          for (const match of line.matchAll(URN_CODE_SPAN_REGEX)) {
+            const urn = match[1];
+            const context = tryExtractTableContext(line);
+            occurrences.push({
+              urn,
+              filePath,
+              line: lineIndex + 1,
+              attribute: context?.attribute ?? null,
+              type: context?.type ?? null,
+            });
+          }
+        }
+      }
+    } catch (error) {
+      console.error(`Failed scanning ${dir}:`, error);
+      process.exitCode = 2;
+      return;
+    }
+  }
+
+  const unique = new Set(occurrences.map((o) => o.urn));
+  const invalid = [];
+  for (const occ of occurrences) {
+    const check = isUrnRfc8141ish(occ.urn);
+    if (!check.ok) invalid.push({ ...occ, reason: check.reason });
+  }
+
+  const byUrn = new Map();
+  for (const occ of occurrences) {
+    const entry = byUrn.get(occ.urn) ?? {
+      urn: occ.urn,
+      attributes: new Set(),
+      types: new Set(),
+      files: new Set(),
+      samples: [],
+    };
+
+    if (occ.attribute) entry.attributes.add(occ.attribute);
+    if (occ.type) entry.types.add(occ.type);
+    entry.files.add(rel(occ.filePath));
+    if (entry.samples.length < 5) entry.samples.push({ file: rel(occ.filePath), line: occ.line, attribute: occ.attribute, type: occ.type });
+
+    byUrn.set(occ.urn, entry);
+  }
+
+  const attributeConflicts = [];
+  const typeConflicts = [];
+
+  for (const entry of byUrn.values()) {
+    if (entry.attributes.size > 1) attributeConflicts.push(entry);
+    if (entry.types.size > 1) typeConflicts.push(entry);
+  }
+
+  // Output
+  console.log('Qualified Names / URN audit');
+  console.log('===========================');
+  console.log('Scanned dirs:');
+  for (const d of SCAN_DIRS) console.log(`- ${rel(d)}`);
+  console.log('');
+  console.log(`Occurrences: ${occurrences.length}`);
+  console.log(`Unique URNs: ${unique.size}`);
+  console.log(`RFC8141-ish invalid: ${invalid.length}`);
+
+  if (invalid.length) {
+    console.log('\nInvalid URNs (first 20):');
+    for (const item of invalid.slice(0, 20)) {
+      console.log(`- ${item.urn} (${item.reason}) @ ${rel(item.filePath)}:${item.line}`);
+    }
+  }
+
+  console.log(`\nPotential conflicts:`);
+  console.log(`- URN used with different attribute labels: ${attributeConflicts.length}`);
+  console.log(`- URN used with different type labels: ${typeConflicts.length}`);
+
+  function printConflict(title, list) {
+    if (!list.length) return;
+    console.log(`\n${title} (first 20):`);
+    for (const entry of list.slice(0, 20)) {
+      console.log(`- ${entry.urn}`);
+      if (entry.attributes.size) console.log(`  attributes: ${Array.from(entry.attributes).join(' | ')}`);
+      if (entry.types.size) console.log(`  types: ${Array.from(entry.types).join(' | ')}`);
+      console.log(`  files: ${Array.from(entry.files).slice(0, 6).join(', ')}${entry.files.size > 6 ? ' …' : ''}`);
+      for (const s of entry.samples) {
+        const meta = [s.attribute ? `attr=${s.attribute}` : null, s.type ? `type=${s.type}` : null].filter(Boolean).join(' ');
+        console.log(`    - ${s.file}:${s.line}${meta ? ` (${meta})` : ''}`);
+      }
+    }
+  }
+
+  printConflict('Conflicts: same URN, different attribute label', attributeConflicts);
+  printConflict('Conflicts: same URN, different type label', typeConflicts);
+
+  if (invalid.length || attributeConflicts.length || typeConflicts.length) {
+    process.exitCode = 1;
+  }
+}
+
+await main();


### PR DESCRIPTION
Branch `502-audit-und-ui-ergaenzungen` – Code-Änderungen für qualifizierte Namen:

**Zweck:**
Dieser Branch enthält die Code-Änderungen (Audit-Tool und UI-Toggle) separat von den fachlichen Dokumentation-Änderungen, wie im Review angeregt.

**Änderungen:**

**1. `src/theme/Root.tsx`  – UI-Toggle für qualifizierte Namen**
- Toggle-Button zum Ein-/Ausblenden der Spalte "Qualifizierter Name" in allen Datenmodell-Tabellen
- Persistenz der Benutzerpräferenz in localStorage (`schulconnex.showQualifiedNames`)
- CSS-Klasse `show-qualified-names` auf `<html>` für globales Styling
- Automatische Erkennung von Tabellen mit Spalte "Qualifizierter Name"
- Toggle erscheint nur auf Seiten mit qualifizierten Namen

**2. `src/css/custom.css` – CSS für Toggle und URN-Display**
- Styling des Toggle-Buttons (Positionierung, Appearance)
- `.show-qualified-names` Klasse: URN-Spalte standardmäßig ausgeblendet
- Ohne Klasse: URN-Spalte sichtbar
- Responsive Anpassungen

**3. `util/audit-qualified-names.mjs` – Audit-Tool**
- Skript zum Prüfen der Konsistenz qualifizierter Namen über alle Datenmodell-Dateien
- Erkennt fehlende, duplizierte oder inkonsistente URNs
- CLI-Tool: `npm run audit:qualified-names`

**4. `package.json`**
- npm-Script `audit:qualified-names` hinzugefügt
- Dependencies `ajv` und `path-browserify` hinzugefügt (für Audit-Tool)

**5. `docusaurus.config.ts` (+24 Zeilen)**
- Webpack-polyfills für `path`-Module (benötigt vom Audit-Tool)
- `createRequire` Import für Node.js-Kompatibilität

**Merge-Reihenfolge:**
Zuerst `502-bestimmte-gute-namen` mergen (Dokumentation), dann `502-audit-und-ui-ergaenzungen` (Code), da beide auf `develop` basieren.
