### PR TITLE
#513 Codeliste Organisationstyp ergänzen um Studienseminar

### DIFF
--- a/docs/codelisten.md
+++ b/docs/codelisten.md
@@ -270,7 +270,9 @@ Anbieter | Anbieter
 Medienzentrum | Medienzentrum
 Behoerde | Behörde
 SchTrae | Schulträger
+Studienseminar | Studienseminar
 Sonstige | sonstige Organisationen / Einrichtungen
+
 
 ## Personenstatus
 

--- a/src/openapi/components-code-Organisationstyp.yaml
+++ b/src/openapi/components-code-Organisationstyp.yaml
@@ -5,6 +5,7 @@ enum:
   - Medienzentrum
   - Behoerde
   - SchTrae
+  - Studienseminar
   - Sonstige
 description: >
     Wie folgt:
@@ -13,4 +14,5 @@ description: >
       * Medienzentrum
       * Behörde
       * Schulträger
+      * Studienseminar
       * Sonstige sonstige Organisationen / Einrichtungen


### PR DESCRIPTION
Studienseminar in Codeliste und in Organisationstyp.yaml eingefügt.