### PR TITLE
#530 Example bei GET /personenkontexte falsch

### DIFF
--- a/src/openapi/paths-personenkontexte.yaml
+++ b/src/openapi/paths-personenkontexte.yaml
@@ -73,7 +73,24 @@ get:
       content:
         application/json:
           schema:
-            $ref: './components-Personen-GET-request.yaml'
+            type: array
+            items:
+              type: object
+              properties:
+                person:
+                  type: object
+                  required:
+                    - id
+                  properties:
+                    id:
+                      description: ID der Person. Wird vom Schulconnex-Server vergeben und ist eindeutig. Dieses Attribut ist unveränderbar (immutable).
+                      type: string
+                      readOnly: true
+                      example: a6e1a860-8d44-4b2b-aef7-aa2c8bf5beb5
+                personenkontexte:
+                  type: array
+                  items:
+                    $ref: './components-qs-Personenkontext-GET-request.yaml'
     '400':
       description: |
         Bad Request


### PR DESCRIPTION
Bei GET /personenkontexte wird nicht mehr das komplette Personen-Objekt geliefert (components-qs-Person-basis.yaml), sondern nur noch der ID Parameter.