### PR TITLE
#533 Falsche Autorisierungsmethode für GET /organisationen-info in YAML Datei

### DIFF
--- a/src/openapi/paths-organisationen-info.yaml
+++ b/src/openapi/paths-organisationen-info.yaml
@@ -3,7 +3,7 @@ get:
     - Organisationen
   operationId: readOrganisationenInfo
   security:
-    - oAuthForUser: []
+    - oAuthForServices: []
   summary: Organisationen auflisten
   description: |
     Die Schnittstelle /organisationen-info ermöglicht die Auflistung von Organisationen durch Dienste.


### PR DESCRIPTION

Fehlerhafte Security/OAuth-Methode (oAuthForUser) durch korrekte Methode (oAuthForServices) ersetzt.