### PR TITLE
#536 Sichtfreigabe kann nicht durch Personenkontext POST/PUT gesetzt …

### DIFF
--- a/src/openapi/components-qs-Personenkontext-POST-request.yaml
+++ b/src/openapi/components-qs-Personenkontext-POST-request.yaml
@@ -17,8 +17,6 @@ properties:
     $ref: './components-code-Personenstatus.yaml'
   jahrgangsstufe:
     $ref: './components-code-Jahrgangsstufe.yaml'
-  sichtfreigabe:
-    $ref: './components-code-Boolean.yaml'
   loeschung:
     description: ''
     type: object

--- a/src/openapi/components-qs-Personenkontext-PUT-request.yaml
+++ b/src/openapi/components-qs-Personenkontext-PUT-request.yaml
@@ -32,8 +32,6 @@ properties:
     $ref: './components-code-Jahrgangsstufe.yaml'
   rolle:
     $ref: './components-code-Rolle.yaml'
-  sichtfreigabe:
-    $ref: './components-code-Boolean.yaml'
   loeschung:
     description: ''
     type: object


### PR DESCRIPTION
…werden

Sichtfreigabe ist bei Personenkontext ein nur lesbarer Wert, daher kann der (boolsche) Wert nicht ueber PUT gesetzt oder mit POST veraendert werden.