### PR TITLE
#539 Attribut 'id' fehlt in der Dienste-API für /organisationen-info

### DIFF
--- a/src/openapi/components-dienste-Organisation.yaml
+++ b/src/openapi/components-dienste-Organisation.yaml
@@ -1,6 +1,10 @@
 description: Organisation.
 type: object
 properties:
+  id:
+    description: ID der Organisation.
+    type: string
+    example: b0d7b0dd-3477-4122-a38d-095ec242e786
   kennung:
     description: Die optionale Kennung (Identifikations-ID) einer Organisation.
     type: string


### PR DESCRIPTION
Attribut hinzugefügt