### PR TITLE
#532 Codeliste Gruppentyp ergänzen um Nutzergruppe

### DIFF
--- a/docs/codelisten.md
+++ b/docs/codelisten.md
@@ -251,6 +251,7 @@ Code | Bezeichnung  | Bemerkung
 --- | --- | --- 
 Klasse | Schulklasse | Eine Schulklasse bezeichnet eine festgelegte Gruppe von Lernenden, die gemeinsam in mehreren Fächern den Unterricht in einer Schule besuchen.
 Kurs | Kurs/Unterricht | Ein Kurs bezeichnet eine Gruppe von Lernenden, welche regelmäßig gemeinsam an einem Fach teilnehmen, aber darüber hinaus nicht weiter strukturiert ist.
+Nutzer | Nutzergruppe | Hiermit ist es möglich Berechtigungen über Gruppen (Nutzergruppen) abzubilden. Details finden sich im Abschnitt [Nutzergruppen für Dienste](praxisleitfaden/nutzer-in-gruppentyp).
 Sonstig | Sonstige Gruppe | Hiermit werden alle Gruppen, die nicht den Definitionen von Klasse oder Kurs entsprechen, gekennzeichnet.
 
 ### Jahrgangsstufe <span class="tag tag-cl-lokal">Lokal</span>

--- a/docs/praxisleitfaden/nutzer-in-gruppentyp.md
+++ b/docs/praxisleitfaden/nutzer-in-gruppentyp.md
@@ -1,0 +1,23 @@
+---
+title: Nutzergruppen für Dienste
+tags: 
+- Informativ
+---
+
+# Nutzergruppen für Dienste
+
+Manche Clients brauchen spezifische Nutzenrollen, die im Schulconnex-Server direkt verwaltet werden sollen. Da nicht für jeden Client neue Organisations- oder Systemrollen angelegt werden können, bietet es sich an, Berechtigungen im System des Clients über Gruppen (Nutzergruppen) abzubilden. 
+
+Um einen Missbrauch zu verhindern, werden Nutzergruppen abgesichert.
+
+Absicherungsmaßnahmen sind z. B.:
+* Nutzergruppen dürfen nicht über die Quellsystem-API angelegt, gelesen, bearbeitet oder gelöscht werden.
+* Nutzergruppen dürfen über die Dienste-API nur an die Clients, für die sich eingerichtet werden, ausgeliefert werden.
+* Nutzergruppen sind am Typ und an der Bezeichnung der Gruppe identifizierbar.
+
+Die Bezeichnungen von Nutzergruppen werden wie Schemaattributfreigaben zentral als Teil der Konfiguration des Dienstes verwaltet.
+
+Die fachliche Umsetzung kann z. B. beeinhalten:
+* Server-Admins können bei der Konfiguration die Bezeichnungen der Nutzergruppen, die der Dienst verwendet, konfigurieren.
+* Gruppen des Typs "Nutzergruppe" werden nicht über die QS-API angelegt, gelesen, bearbeitet oder gelöscht.
+* Gruppen und Gruppenzugehörigkeiten vom Typ "Nutzergruppe" werden an /person-info und /personen-info nur ausgeliefert wenn für den aufrufenden Dienst eine Nutzergruppe mit der entsprechenden Bezeichnung konfiguriert oder zugeordnet wurde.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -191,6 +191,7 @@ const sidebars: SidebarsConfig = {
       },
       items: [
         'praxisleitfaden/ablauf-löschen-dienste',
+        'praxisleitfaden/nutzer-in-gruppentyp',
       ],
     },
 

--- a/src/openapi/components-code-Gruppentyp.yaml
+++ b/src/openapi/components-code-Gruppentyp.yaml
@@ -2,9 +2,11 @@ type: string
 enum:
   - Klasse
   - Kurs
+  - Nutzer
   - Sonstig
 description: >
     Wie folgt:
       * Klasse Schulklasse
       * Kurs Kurs/Unterricht
+      * Nutzer Nutzergruppe 
       * Sonstig Sonstige Gruppe


### PR DESCRIPTION
Neuer Wert "Nutzer/Nutzergruppe" in Codeliste Gruppentyp. 
Neue Seite "Nutzergruppen für Dienste" unter Praxisleitfaden-Dienste. 
(Seite erstellt und mit Informationen aus dem Github-Ticket gefüllt. Muss eventuell überarbeitet werden.)