### PR TITLE
#546 APIs zum Erstellen, Lesen und Löschen von Organisationsbeziehungen

### DIFF
--- a/docs/datenmodell-qs/beziehung.md
+++ b/docs/datenmodell-qs/beziehung.md
@@ -16,4 +16,3 @@ id | String (UTF-8) | 1 | ID der Beziehung.
 mandant | String (UTF-8) | 1 | ID des Mandanten, dem die Beziehung zugeordnet ist. Wird vom Schulconnex-Server vergeben und ist eindeutig. Dieses Attribut ist unveränderbar (immutable).
 ktid | String (UTF-8) | 1 | ID des Personenkontexts, zu dem eine Beziehung besteht.
 beziehung | String (UTF-8) | 1 | Beziehung aus Codeliste *Beziehungen*.
-revision | String (UTF-8) | 1 | Revision der Beziehung. Wird vom Schulconnex-Server mit der Erstellung des Datensatzes sowie Aktualisierung generiert. Dieser Wert kann nicht von Quellsystemen oder Diensten gesetzt werden.

--- a/docs/datenmodell-qs/datenmodell.md
+++ b/docs/datenmodell-qs/datenmodell.md
@@ -34,7 +34,6 @@ classDiagram
     mandant
     ktid
     beziehung
-    revision
   }
   class Person {
     id

--- a/docs/datenmodell-qs/organisationsbeziehung.md
+++ b/docs/datenmodell-qs/organisationsbeziehung.md
@@ -14,3 +14,4 @@ Attribut | Typ | Anzahl | Bemerkung
 --- | --- | --- | ---
 orgid | String (UTF-8) | 1 | Id der Organisation, zu der die „hat_als“-Beziehung besteht.
 organisationsbeziehung | String (UTF-8) | 1..n | Beziehung aus Codeliste *Organisationsbeziehungen*.
+revision | String (UTF-8) |	1 | Revision der Organisationsbeziehung. Wird vom Schulconnex-Server mit der Erstellung des Datensatzes sowie Aktualisierung generiert. Dieser Wert kann nicht von Quellsystemen oder Diensten gesetzt werden.

--- a/docs/datenmodell-qs/organisationsbeziehung.md
+++ b/docs/datenmodell-qs/organisationsbeziehung.md
@@ -14,4 +14,3 @@ Attribut | Typ | Anzahl | Bemerkung
 --- | --- | --- | ---
 orgid | String (UTF-8) | 1 | Id der Organisation, zu der die „hat_als“-Beziehung besteht.
 organisationsbeziehung | String (UTF-8) | 1..n | Beziehung aus Codeliste *Organisationsbeziehungen*.
-revision | String (UTF-8) |	1 | Revision der Organisationsbeziehung. Wird vom Schulconnex-Server mit der Erstellung des Datensatzes sowie Aktualisierung generiert. Dieser Wert kann nicht von Quellsystemen oder Diensten gesetzt werden.

--- a/docs/english-api-notes/data-models.md
+++ b/docs/english-api-notes/data-models.md
@@ -179,7 +179,6 @@ Attribute | Description
 id | ID of the relation.
 ktid | ID of the person context to the person who has the relationship. For example, if the relation is „legal guardian”, then the person with the current person context is the person with the legal guardian, while the person with the person context with the `ktid` is the legal guardian.
 beziehung | Relations. Refers to code list *Beziehungen*.
-revision | Revision number of the information. This is mainly used to check on updates and deletes of data sets, whether there have been any changes to the data since it was retrieved by the client system.
 
 ## Anschrift
 

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -429,15 +429,51 @@ const sidebars: SidebarsConfig = {
             },
             {
               type: 'doc',
+              id: 'generated/openapi/quellsysteme/read-organisation-info',
+              label: '/organisation-info',
+              className: 'api-method get',
+            },
+            {
+              type: 'doc',
               id: 'generated/openapi/quellsysteme/read-organisation-id-organisationsbeziehungen',
               label: '/organisationen/\u200B:id/\u200Borganisationsbeziehungen',
               className: 'api-method get',
             },
             {
               type: 'doc',
-              id: 'generated/openapi/quellsysteme/read-organisation-info',
-              label: '/organisation-info',
+              id: 'generated/openapi/quellsysteme/create-organisationsbeziehung',
+              label: '/organisationen/\u200B:id/\u200Borganisationsbeziehungen',
+              className: 'api-method post',
+            },
+          ],
+        },
+           {
+          type: 'category',
+          label: 'Organisationsbeziehungen',
+          items: [
+            {
+              type: 'doc',
+              id: 'generated/openapi/quellsysteme/read-organisation-id-organisationsbeziehungen',
+              label: '/organisationen/\u200B:id/\u200Borganisationsbeziehungen',
               className: 'api-method get',
+            },
+            {
+              type: 'doc',
+              id: 'generated/openapi/quellsysteme/create-organisationsbeziehung',
+              label: '/organisationen/\u200B:id/\u200Borganisationsbeziehungen',
+              className: 'api-method post',
+            },
+            {
+              type: 'doc',
+              id: 'generated/openapi/quellsysteme/read-organisationsbeziehung-id',
+              label: '/organisationsbeziehungen/\u200B:id',
+              className: 'api-method get',
+            },
+            {
+              type: 'doc',
+              id: 'generated/openapi/quellsysteme/delete-organisationsbeziehung-id',
+              label: '/organisationsbeziehungen/\u200B:id',
+              className: 'api-method delete',
             },
           ],
         },

--- a/src/openapi/api-qs.yaml
+++ b/src/openapi/api-qs.yaml
@@ -53,6 +53,8 @@ paths:
     $ref: './paths-organisationen-id.yaml'
   /organisationen/{id}/organisationsbeziehungen:
     $ref: './paths-organisationen-id-organisationsbeziehungen.yaml'
+  /organisationsbeziehungen/{id}:
+    $ref: './paths-organisationsbeziehungen-id.yaml'
   /organisation-info:
     $ref: './paths-organisation-info.yaml'
   /gruppen:

--- a/src/openapi/components-Sichtfreigabe.yaml
+++ b/src/openapi/components-Sichtfreigabe.yaml
@@ -14,6 +14,6 @@ properties:
     type: string
     example: c1966d20-50b6-4bb1-afc7-96663523891e
   revision:
-    description: Revision der Beziehung.
+    description: Revision der Sichtfreigabe.
     type: string
     example: "1"

--- a/src/openapi/components-qs-Beziehung-basis.yaml
+++ b/src/openapi/components-qs-Beziehung-basis.yaml
@@ -21,7 +21,3 @@ properties:
     example: 553f984f-5fea-48c8-ae26-089420465803
   beziehung:
     $ref: './components-code-Beziehungen.yaml'
-  revision:
-    description: Revision der Beziehung.
-    type: string
-    example: "2"

--- a/src/openapi/components-qs-Organisationsbeziehung.yaml
+++ b/src/openapi/components-qs-Organisationsbeziehung.yaml
@@ -8,7 +8,3 @@ properties:
     description: Beziehung aus Codeliste [Organisationsbeziehungen](../../../codelisten#organisationsbeziehungen).
     type: string
     example: SchBeh
-  revision:
-    description: Revision der organisationsbeziehung.
-    type: string
-    example: "1"

--- a/src/openapi/components-qs-Organisationsbeziehung.yaml
+++ b/src/openapi/components-qs-Organisationsbeziehung.yaml
@@ -8,3 +8,7 @@ properties:
     description: Beziehung aus Codeliste [Organisationsbeziehungen](../../../codelisten#organisationsbeziehungen).
     type: string
     example: SchBeh
+  revision:
+    scription: Revision der organisationsbeziehung.
+    type: string
+    example: "1"

--- a/src/openapi/components-qs-Organisationsbeziehung.yaml
+++ b/src/openapi/components-qs-Organisationsbeziehung.yaml
@@ -9,6 +9,6 @@ properties:
     type: string
     example: SchBeh
   revision:
-    scription: Revision der organisationsbeziehung.
+    description: Revision der organisationsbeziehung.
     type: string
     example: "1"

--- a/src/openapi/paths-beziehungen-id.yaml
+++ b/src/openapi/paths-beziehungen-id.yaml
@@ -73,10 +73,6 @@ delete:
 
     Ein DELETE zum Löschen einer Beziehung per `beziehung.id` muss mit HTTP-DELETE auf die API `/beziehungen/{beziehung.id}` erfolgen.
 
-    Es ist erforderlich, dass für eine Löschanfrage einer Beziehung das Attribut `revision`
-    der zugrunde liegenden Beziehung mitgeschickt wird. Der Schulconnex-Server überprüft
-    anhand des mitgeschickten Werts des Attributs `revision`, ob der Datensatz in
-    der Zwischenzeit keine Änderung erfahren hat.
   parameters:
     - in: path
       name: id
@@ -84,18 +80,6 @@ delete:
         type: string
       required: true
       description: Der Pfad-Parameter bezieht sich auf die ID der Beziehung.
-  requestBody:
-    required: true
-    content:
-      application/json:
-        schema:
-          type: object
-          required:
-            - revision
-          properties:
-            revision:
-              type: string
-              description: Revision der zugrunde liegenden Beziehung. Dieses Feld ist ein Pflichtfeld.
   responses:
     '204':
       description: |
@@ -105,13 +89,6 @@ delete:
     '400':
       description: |
         Bad Request
-
-        Subcode 13: „Personenkontext wird genutzt." Dieser Fehler wird gemeldet, wenn
-        Daten eines Personenkontexts bereits im Zusammenhang mit einem Anmeldevorgang an
-        Dienste weitergeleitet wurden. In dem Fall muss die Löschung durch Setzen eines
-        Löschzeitpunkts erfolgen, um sicherzustellen, dass andere Dienste über die Löschung
-        informiert werden und eventuell existierende Information bei den Diensten gelöscht
-        werden können.
 
         Siehe [Fehlerbehandlung](../../../schnittstellendefinition/http-statuscodes)
     '401':

--- a/src/openapi/paths-organisationen-id-organisationsbeziehungen.yaml
+++ b/src/openapi/paths-organisationen-id-organisationsbeziehungen.yaml
@@ -32,7 +32,6 @@ post:
     Attribut | In den Anfrage-Nutzdaten erforderlich? | Bemerkung
     --- | --- | ---
     `id` | nein | ID der Organisationsbeziehung. Wird vom Schulconnex-Server vergeben und ist eindeutig. Dieses Attribut ist unveränderbar (immutable).
-    `revision` | nein | Revision der Organisationsbeziehung. Wird vom Schulconnex-Server mit der Erstellung des Datensatzes sowie Aktualisierung generiert. Dieser Wert kann nicht von Quellsystemen oder Diensten gesetzt werden.
 
     Bei einer erfolgreichen Anforderung zum Erstellen einer Organisationsbeziehung
     wird diese Anforderung mit einer Repräsentation der Beziehung in den Antwort-Nutzdaten

--- a/src/openapi/paths-organisationen-id-organisationsbeziehungen.yaml
+++ b/src/openapi/paths-organisationen-id-organisationsbeziehungen.yaml
@@ -1,3 +1,107 @@
+post:
+  tags:
+    - Organisationen
+    - Organisationsbeziehungen
+  operationId: createOrganisationsbeziehung
+  security:
+    - oAuthForServices: []
+  summary: Erstellen einer Organisationsbeziehung
+  description: |
+    Die Schnittstelle `/organisationen/{id}/organisationsbeziehungen` erlaubt
+    das Erstellen einer Organisationsbeziehung für eine Organisatiom
+
+    Organisationsbeziehungen sind immer von der Form „hat_als“. Besteht zum Beispiel
+    von Organisation A eine Organisationsbeziehung vom Typ `Medienzentrum` zu einer Organisation B,
+    so bedeutet dieses, dass Organisation A die Organisation B als Medienzentrum hat.
+
+    Ein CREATE zum Erstellen von Organisationsbeziehungen muss mit HTTP-POST auf die API 
+    `/organisationen/{id}/organisationsbeziehungen` erfolgen. Die Anfrage-Nutzdaten
+    (Request Payload) beinhalten ein JSON-Objekt des Datentyps Organisationsbeziehung.
+
+    Siehe auch Datenmodell [`Organisationsbeziehung`](../../../datenmodell-qs/organisationsbeziehung).
+
+    Diese API ist häufig nur als interne API für den Betreiber einens Schulconnex-Servers 
+    zur Durchführung administrativer Funktionen verfügbar.
+
+    Bestehen zwischen zwei Organisationen mehrere Organisationsbeziehungen, so ist
+    für jede Einzelbeziehung ein eigenes Organisationsbeziehungsobjekt zu erstellen.
+
+    Die folgende Tabelle listet die Attribute einer Organisationsbeziehung auf, welche von einem
+    Quellsystem oder Dienst nicht verändert werden können.
+
+    Attribut | In den Anfrage-Nutzdaten erforderlich? | Bemerkung
+    --- | --- | ---
+    `id` | nein | ID der Organisationsbeziehung. Wird vom Schulconnex-Server vergeben und ist eindeutig. Dieses Attribut ist unveränderbar (immutable).
+    `revision` | nein | Revision der Organisationsbeziehung. Wird vom Schulconnex-Server mit der Erstellung des Datensatzes sowie Aktualisierung generiert. Dieser Wert kann nicht von Quellsystemen oder Diensten gesetzt werden.
+
+    Bei einer erfolgreichen Anforderung zum Erstellen einer Organisationsbeziehung
+    wird diese Anforderung mit einer Repräsentation der Beziehung in den Antwort-Nutzdaten
+    und dem HTTP-Statuscode 201 quittiert.
+  parameters:
+    - in: path
+      name: id
+      schema:
+        type: string
+        example: 4d0f579c-0b9a-4d3a-b484-87b3bee8a2ad
+      required: true
+      description: Der Pfad-Parameter bezieht sich auf die ID der Organisation welche die Organisationsbeziehung hat
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+        type: object
+        properties:
+          orgid:
+            required: true
+            description: ID der Organisation.
+            type: string
+            example: 9b3f36ad-9d15-49f9-9660-6cf9746ba446
+          organisationsbeziehung:
+            required: true
+            description: Beziehung aus Codeliste [Organisationsbeziehungen](../../../codelisten#organisationsbeziehungen).
+            type: string
+            example: SchBeh
+  responses:
+    '201':
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: './components-qs-Organisationsbeziehung.yaml'
+    '400':
+      description: |
+        Bad Request
+
+        Subcode 18: „Beziehung kann nicht erstellt werden.“ Dieser Fehler wird gemeldet,
+        wenn die zu erstellende Organisationsbeziehung nicht unterstützt werden kann.        
+
+        Siehe [Fehlerbehandlung](../../../schnittstellendefinition/http-statuscodes-qs)
+    '401':
+      description: |
+        Unauthorized
+
+        Siehe [Fehlerbehandlung](../../../schnittstellendefinition/http-statuscodes-qs)
+    '403':
+      description: |
+        Forbidden
+
+        Siehe [Fehlerbehandlung](../../../schnittstellendefinition/http-statuscodes-qs)
+    '404':
+      description: |
+        Not found
+
+        Siehe [Fehlerbehandlung](../../../schnittstellendefinition/http-statuscodes-qs)
+    '405':
+      description: |
+        Method not allowed
+
+        Siehe [Fehlerbehandlung](../../../schnittstellendefinition/http-statuscodes-qs)
+    '409':
+      description: |
+        Conflict
+
+        Siehe [Fehlerbehandlung](../../../schnittstellendefinition/http-statuscodes-qs)
 get:
   tags:
     - Organisationen

--- a/src/openapi/paths-organisationen-id-organisationsbeziehungen.yaml
+++ b/src/openapi/paths-organisationen-id-organisationsbeziehungen.yaml
@@ -50,18 +50,19 @@ post:
     content:
       application/json:
         schema:
-        type: object
-        properties:
-          orgid:
-            required: true
-            description: ID der Organisation.
-            type: string
-            example: 9b3f36ad-9d15-49f9-9660-6cf9746ba446
-          organisationsbeziehung:
-            required: true
-            description: Beziehung aus Codeliste [Organisationsbeziehungen](../../../codelisten#organisationsbeziehungen).
-            type: string
-            example: SchBeh
+          type: object
+          required:
+             - orgid
+             - organisationsbeziehung
+          properties:
+            orgid:
+              description: ID der Organisation.
+              type: string
+              example: 9b3f36ad-9d15-49f9-9660-6cf9746ba446
+            organisationsbeziehung:
+              description: Beziehung aus Codeliste [Organisationsbeziehungen](../../../codelisten#organisationsbeziehungen).
+              type: string
+              example: SchBeh
   responses:
     '201':
       description: OK

--- a/src/openapi/paths-organisationen-id-organisationsbeziehungen.yaml
+++ b/src/openapi/paths-organisationen-id-organisationsbeziehungen.yaml
@@ -43,7 +43,7 @@ post:
         type: string
         example: 4d0f579c-0b9a-4d3a-b484-87b3bee8a2ad
       required: true
-      description: Der Pfad-Parameter bezieht sich auf die ID der Organisation welche die Organisationsbeziehung hat
+      description: Der Pfad-Parameter bezieht sich auf die ID der Organisation, welche die Organisationsbeziehung hat.
   requestBody:
     required: true
     content:

--- a/src/openapi/paths-organisationen-id-organisationsbeziehungen.yaml
+++ b/src/openapi/paths-organisationen-id-organisationsbeziehungen.yaml
@@ -8,7 +8,7 @@ post:
   summary: Erstellen einer Organisationsbeziehung
   description: |
     Die Schnittstelle `/organisationen/{id}/organisationsbeziehungen` erlaubt
-    das Erstellen einer Organisationsbeziehung für eine Organisatiom
+    das Erstellen einer Organisationsbeziehung für eine Organisation.
 
     Organisationsbeziehungen sind immer von der Form „hat_als“. Besteht zum Beispiel
     von Organisation A eine Organisationsbeziehung vom Typ `Medienzentrum` zu einer Organisation B,

--- a/src/openapi/paths-organisationsbeziehungen-id.yaml
+++ b/src/openapi/paths-organisationsbeziehungen-id.yaml
@@ -67,10 +67,6 @@ delete:
     Diese API ist häufig nur als interne API für den Betreiber einens Schulconnex-Servers 
     zur Durchführung administrativer Funktionen verfügbar.
 
-    Es ist erforderlich, dass für eine Löschanfrage einer Organisationsbeziehung das Attribut `revision`
-    der zugrunde liegenden Organisationsbeziehung mitgeschickt wird. Der Schulconnex-Server überprüft
-    anhand des mitgeschickten Werts des Attributs `revision`, ob der Datensatz in
-    der Zwischenzeit keine Änderung erfahren hat.
   parameters:
     - in: path
       name: id
@@ -78,18 +74,6 @@ delete:
         type: string
       required: true
       description: Der Pfad-Parameter bezieht sich auf die ID der Organisationsbeziehung.
-  requestBody:
-    required: true
-    content:
-      application/json:
-        schema:
-          type: object
-          required:
-            - revision
-          properties:
-            revision:
-              type: string
-              description: Revision der zugrunde liegenden Organisationsbeziehung. Dieses Feld ist ein Pflichtfeld.
   responses:
     '204':
       description: |

--- a/src/openapi/paths-organisationsbeziehungen-id.yaml
+++ b/src/openapi/paths-organisationsbeziehungen-id.yaml
@@ -1,0 +1,128 @@
+get:
+  tags:
+    - Organisationsbeziehungen
+  operationId: readOrganisationsbeziehungId
+  security:
+    - oAuthForServices: []
+  summary: Organisationsbeziehung zur angeforderten ID
+  description: |
+    Dieser Schnittstellenendpunkt gibt die Organisationsbeziehung zur angegebenen `organisationsbeziehung.id` zurück.
+
+    Ein READ zum Abfragen einer Organisationsbeziehung per ID muss mit HTTP-GET auf die API `/organisatinsbeziehungen/{organisationsbeziehung.id}` erfolgen. Die Antwort-Nutzdaten (Response Payload) beinhalten
+    ein JSON-Objekt des Datentyps Organisationsbeziehung.
+
+    Siehe auch Datenmodell [`Organisationsbeziehung`](../../../datenmodell-qs/organisationsbeziehung).
+
+  parameters:
+    - in: path
+      name: id
+      required: true
+      schema:
+        type: string
+      description: Der Pfad-Parameter bezieht sich auf die ID der Organisationsbeziehung.
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: './components-qs-Organisationsbeziehung.yaml'
+    '400':
+      description: |
+        Bad Request
+
+        Siehe [Fehlerbehandlung](../../../schnittstellendefinition/http-statuscodes)
+    '401':
+      description: |
+        Unauthorized
+
+        Siehe [Fehlerbehandlung](../../../schnittstellendefinition/http-statuscodes)
+    '403':
+      description: |
+        Forbidden
+
+        Siehe [Fehlerbehandlung](../../../schnittstellendefinition/http-statuscodes)
+    '404':
+      description: |
+        Not found
+
+        Siehe [Fehlerbehandlung](../../../schnittstellendefinition/http-statuscodes)
+    '405':
+      description: |
+        Method not allowed
+
+        Siehe [Fehlerbehandlung](../../../schnittstellendefinition/http-statuscodes)
+delete:
+  tags:
+    - Organisationsbeziehungen
+  operationId: deleteOrganisationsbeziehungId
+  security:
+    - oAuthForServices: []
+  summary: Löscht die Organisationsbeziehung zur angeforderten ID
+  description: |
+    Dieser Schnittstellenendpunkt löscht die Organisationsbeziehung zur angegebenen `organisationsbeziehung.id`.
+
+    Ein DELETE zum Löschen einer Organisationsbeziehung per `organisationsbeziehung.id` muss mit HTTP-DELETE auf die API `/organisationsbeziehungen/{organisationsbeziehung.id}` erfolgen.
+
+    Diese API ist häufig nur als interne API für den Betreiber einens Schulconnex-Servers 
+    zur Durchführung administrativer Funktionen verfügbar.
+
+    Es ist erforderlich, dass für eine Löschanfrage einer Organisationsbeziehung das Attribut `revision`
+    der zugrunde liegenden Organisationsbeziehung mitgeschickt wird. Der Schulconnex-Server überprüft
+    anhand des mitgeschickten Werts des Attributs `revision`, ob der Datensatz in
+    der Zwischenzeit keine Änderung erfahren hat.
+  parameters:
+    - in: path
+      name: id
+      schema:
+        type: string
+      required: true
+      description: Der Pfad-Parameter bezieht sich auf die ID der Organisationsbeziehung.
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          required:
+            - revision
+          properties:
+            revision:
+              type: string
+              description: Revision der zugrunde liegenden Organisationsbeziehung. Dieses Feld ist ein Pflichtfeld.
+  responses:
+    '204':
+      description: |
+        No Content
+
+        Bei einer erfolgreichen Ausführung der Löschanfrage wird es keine Antwort-Nutzdaten (Response Payload) geben.
+    '400':
+      description: |
+        Bad Request
+
+        Siehe [Fehlerbehandlung](../../../schnittstellendefinition/http-statuscodes)
+    '401':
+      description: |
+        Unauthorized
+
+        Siehe [Fehlerbehandlung](../../../schnittstellendefinition/http-statuscodes)
+    '403':
+      description: |
+        Forbidden
+
+        Siehe [Fehlerbehandlung](../../../schnittstellendefinition/http-statuscodes)
+    '404':
+      description: |
+        Not found
+
+        Siehe [Fehlerbehandlung](../../../schnittstellendefinition/http-statuscodes)
+    '405':
+      description: |
+        Method not allowed
+
+        Siehe [Fehlerbehandlung](../../../schnittstellendefinition/http-statuscodes)
+    '409':
+      description: |
+        Conflict
+
+        Siehe [Fehlerbehandlung](../../../schnittstellendefinition/http-statuscodes)

--- a/src/openapi/paths-personenkontexte-id-beziehungen.yaml
+++ b/src/openapi/paths-personenkontexte-id-beziehungen.yaml
@@ -38,8 +38,7 @@ post:
     Attribut | In den Anfrage-Nutzdaten erforderlich? | Bemerkung
     --- | --- | ---
     `id` | nein | ID der Beziehung. Wird vom Schulconnex-Server vergeben und ist eindeutig. Dieses Attribut ist unveränderbar (immutable).
-    `revision` | nein | Revision der Beziehung. Wird vom Schulconnex-Server mit der Erstellung des Datensatzes sowie Aktualisierung generiert. Dieser Wert kann nicht von Quellsystemen oder Diensten gesetzt werden.
-
+  
     Bei einer erfolgreichen Anforderung zum Erstellen einer Beziehung zu einem Personenkontext
     wird diese Anforderung mit einer Repräsentation der Beziehung in den Antwort-Nutzdaten
     und dem HTTP-Statuscode 201 quittiert.


### PR DESCRIPTION
CREATE/GET/DELETE für Organisationsbeziehungen (entsprechend zu Beziehungen zwischen Personenkontexten). 

Kein POST/PATCH, da Organisationsbeziehungen nicht modifiziert werden können (nur gelöscht und neu erstellt). 

Attribut REVISION hinzugefügt, um Beziehungen zu entsprechen - kann eventuell wieder entfernt werden (Issue #550). 

Seitenstruktur (sidebar.ts) wie bei Beziehungen strukturiert. Eigene Kategorie für Organisationsbeziehungen, aber Lesen und Erstellen (da über organisationen/:id/organisationsbeziehungen) zusätzlich auch bei Organisationen gelistet.