### PR TITLE
#545 API zum PATCH von Organisationen

### DIFF
--- a/sidebars.ts
+++ b/sidebars.ts
@@ -429,6 +429,12 @@ const sidebars: SidebarsConfig = {
             },
             {
               type: 'doc',
+              id: 'generated/openapi/quellsysteme/patch-organisation-id',
+              label: '/organisationen/\u200B:id',
+              className: 'api-method patch',
+            },
+            {
+              type: 'doc',
               id: 'generated/openapi/quellsysteme/read-organisation-id-organisationsbeziehungen',
               label: '/organisationen/\u200B:id/\u200Borganisationsbeziehungen',
               className: 'api-method get',

--- a/src/openapi/components-qs-Organisation-PATCH-request.yaml
+++ b/src/openapi/components-qs-Organisation-PATCH-request.yaml
@@ -1,0 +1,63 @@
+type: object
+required:
+  - revision
+properties:
+  id:
+    description: ID der Organisation.
+    type: string
+    example: b0d7b0dd-3477-4122-a38d-095ec242e786
+  kennung:
+    description: Die optionale Kennung (Identifikations-ID) einer Organisation.
+    type: string
+    nullable: true
+    example: NI_12345
+  name:
+    description: Offizieller Name einer Organisation.
+    type: string   
+    nullable: true
+    example: Heinrich-Heine-Gymnasium
+  namensergaenzung:
+    description: Ergänzender Name einer Organisation.
+    type: string
+    nullable: true
+    example: vorher Heinrich-Heine-Gesamtschule
+  kuerzel:
+    description: Kurzname einer Organisation.
+    type: string
+    maxLength: 64
+    nullable: true
+    example: Heine-Gym
+  anschrift:
+    type: object
+    properties:
+      postleitzahl:
+        description: Postleitzahl.
+        type: string
+        nullable: true
+        example: "30519"
+      ort:
+        description: Amtlicher Gemeindename.
+        type: string
+        nullable: true
+        example: Hannover
+      ortsteil:
+        description: Teil eines Orts, falls genauere Untergliederung gewünscht.
+        type: string
+        nullable: true
+        example: Döhren
+      verwaltungspolitischekodierung:
+        properties:
+          bundesland:
+           nullable: true
+           $ref: './components-code-Bundesland.yaml'
+  typ:
+    nullable: true
+    $ref: './components-code-Organisationstyp.yaml'
+  traegerschaft:
+    nullable: true
+    $ref: './components-code-Trägerschaft.yaml'
+  revision:
+    description: Revision des Organisationsdatensatzes.
+    type: string
+
+

--- a/src/openapi/paths-organisationen-id.yaml
+++ b/src/openapi/paths-organisationen-id.yaml
@@ -99,7 +99,7 @@ patch:
     
     Bei einer erfolgreichen Anforderung zum Modifizieren eines Organisationsdatensatzes wird
     diese Anforderung mit einer Repräsentation des Organisationsdatensatzes in den
-    Antwort-Nutzdaten und dem HTTP Status Code 201 quittiert.
+    Antwort-Nutzdaten und dem HTTP-Status-Code 201 quittiert.
   parameters:
     - in: path
       name: id

--- a/src/openapi/paths-organisationen-id.yaml
+++ b/src/openapi/paths-organisationen-id.yaml
@@ -98,7 +98,7 @@ patch:
     beispielsweise {"kuerzel": null}. 
     
     Bei einer erfolgreichen Anforderung zum Modifizieren eines Organisationsdatensatzes wird
-    diese Anforderung mit einer ReprÃ¤sentation des Organisationsdatensatzes in den
+    diese Anforderung mit einer Repräsentation des Organisationsdatensatzes in den
     Antwort-Nutzdaten und dem HTTP Status Code 201 quittiert.
   parameters:
     - in: path

--- a/src/openapi/paths-organisationen-id.yaml
+++ b/src/openapi/paths-organisationen-id.yaml
@@ -88,7 +88,7 @@ patch:
     im Request dennoch vorhanden, wird es validiert und führt
     gegebenenfalls zu einer Fehlermeldung.
     
-    Dieser Endpunkt stellt eine HTTP-PATCH Operation bereit, 
+    Dieser Endpunkt stellt eine HTTP-PATCH-Operation bereit, 
     bei der ausschließlich die zu modifizierenden Attribute in der 
     Anfrage-Nutzlast mitgeschickt werden müssen. 
     Werte von Attributen, welche nicht in der Anfrage-Nutzlast mitgeschickt werden, 

--- a/src/openapi/paths-organisationen-id.yaml
+++ b/src/openapi/paths-organisationen-id.yaml
@@ -58,3 +58,106 @@ get:
         Method not allowed
 
         Siehe [Fehlerbehandlung](../../../schnittstellendefinition/http-statuscodes-qs)
+patch:
+  tags:
+    - Organisationen
+  operationId: patchOrganisationId
+  security:
+    - oAuthForServices: []
+  summary: Modifizieren einer Organisation
+  description: |
+    Mittels dieser Schnittstelle wird eine bestehende Organisation modifiziert.
+
+    Ein PATCH zum Modifizieren von Organisationendatensätzen muss mit HTTP-PATCH auf die API `/organisationen/{organisation.id}`
+    erfolgen. Die Anfrage-Nutzdaten (Request Payload) beinhalten ein JSON-Objekt des Datentyps
+    Organisation. Siehe auch das Datenmodell zu
+    [`Organisation`](../../../datenmodell-qs/organisation).
+
+    Diese API ist häufig nur als interne API für den Betreiber einens Schulconnex-Servers 
+    zur Durchführung administrativer Funktionen verfügbar.
+
+    Die folgende Tabelle listet die Attribute einer Organisation auf,
+    welche von einem Quellsystem oder Dienst nicht gesetzt werden können.
+
+    Attribut | In den Anfrage-Nutzdaten erforderlich? | Bemerkung
+    --- | --- | ---
+    `id` | nein | ID der Organisation. Wird vom Schulconnex-Server vergeben und ist eindeutig. Dieses Attribut ist unveränderbar (immutable).
+    `revision` | ja | Revision der Organisation. Wird vom Schulconnex-Server mit der Erstellung des Datensatzes sowie Aktualisierung generiert. Dieser Wert kann nicht von Quellsystemen oder Diensten gesetzt werden.
+    
+    Das Attribut id kann im Request ausgelassen werden. Ist es
+    im Request dennoch vorhanden, wird es validiert und führt
+    gegebenenfalls zu einer Fehlermeldung.
+    
+    Dieser Endpunkt stellt eine HTTP-PATCH Operation bereit, 
+    bei der ausschließlich die zu modifizierenden Attribute in der 
+    Anfrage-Nutzlast mitgeschickt werden müssen. 
+    Werte von Attributen, welche nicht in der Anfrage-Nutzlast mitgeschickt werden, 
+    bleiben unverändert.
+    
+    Um einen Wert zu löschen, muss der Wert des Attributs auf null gesetzt werden, 
+    beispielsweise {"kuerzel": null}. 
+    
+    Bei einer erfolgreichen Anforderung zum Modifizieren eines Organisationsdatensatzes wird
+    diese Anforderung mit einer ReprÃ¤sentation des Organisationsdatensatzes in den
+    Antwort-Nutzdaten und dem HTTP Status Code 201 quittiert.
+  parameters:
+    - in: path
+      name: id
+      required: true
+      schema:
+        type: string
+        example: 9b3f36ad-9d15-49f9-9660-6cf9746ba446
+      description: Der Pfad-Parameter bezieht sich auf die ID der Organisation.    
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+         $ref: './components-qs-Organisation-PATCH-request.yaml'
+  responses:
+    '201':
+      description: OK
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: './components-Organisation-basis.yaml'
+              - $ref: './components-Organisation.yaml'
+              - $ref: './components-qs-Organisation.yaml'
+    '304':
+      description: Not Modified
+    '400':
+      description: |
+        Bad Request
+
+        Siehe [Fehlerbehandlung](../../../schnittstellendefinition/http-statuscodes-qs)
+    '401':
+      description: |
+        Unauthorized
+
+        Siehe [Fehlerbehandlung](../../../schnittstellendefinition/http-statuscodes-qs)
+    '403':
+      description: |
+        Forbidden
+
+        Siehe [Fehlerbehandlung](../../../schnittstellendefinition/http-statuscodes-qs)
+    '404':
+      description: |
+        Not found
+
+        Siehe [Fehlerbehandlung](../../../schnittstellendefinition/http-statuscodes-qs)
+    '405':
+      description: |
+        Method not allowed
+
+        Siehe [Fehlerbehandlung](../../../schnittstellendefinition/http-statuscodes-qs)
+    '409':
+      description: |
+        Conflict
+
+        Siehe [Fehlerbehandlung](../../../schnittstellendefinition/http-statuscodes-qs)
+    '501':
+      description: |
+        Not Implemented
+
+        Siehe [Fehlerbehandlung](../../../schnittstellendefinition/http-statuscodes-qs)


### PR DESCRIPTION
Für Issue #538 wurden APIs zum Erstellen, Aktualisieren (mit PUT) und Löschen von Organisationen bereit gestellt. 
Dieses Commit fügt auch noch die Modifikation von Organisationen mit PATCH hinzu.