### PR TITLE
#553 'siteConfig.onBrokenMarkdownLinks' depreciated Warnung

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -19,7 +19,6 @@ const config: Config = {
   projectName: 'schulconnex', // Usually your repo name.
 
   onBrokenLinks: 'throw',
-  onBrokenMarkdownLinks: 'throw',
 
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you
@@ -34,6 +33,9 @@ const config: Config = {
     remarkRehypeOptions: {
       footnoteLabel: 'Fußnoten',
     },
+    hooks: {
+      onBrokenMarkdownLinks: 'throw'
+    }
   },
 
   themes: [


### PR DESCRIPTION
Option `onBrokenMarkdownLinks` vom Top-Level (deprechiated ab v4) in die Markdown/Hooks Optionen verschoben.