### PR TITLE
#555 Warnungen aus 'validate-openapi' abarbeiten

### DIFF
--- a/src/openapi/components-dienste-Gruppe.yaml
+++ b/src/openapi/components-dienste-Gruppe.yaml
@@ -43,7 +43,7 @@ properties:
       $ref: './components-code-Jahrgangsstufe.yaml'
   faecher:
     type: array
-    example: [{kennung: "DE"},{bezeichnung: "Erste Hilfe"}]
+    example: [{kennung: "DE", bezeichnung: "Erste Hilfe"}]
     items:
      oneOf:
       - $ref: './components-Gruppe-faecher-kennung.yaml'

--- a/src/openapi/components-dienste-Person.yaml
+++ b/src/openapi/components-dienste-Person.yaml
@@ -1,6 +1,7 @@
 type: object
 required:
   - name
+  - vertrauensstufe
 properties:
   stammorganisation:
     allOf:
@@ -11,7 +12,6 @@ properties:
     required:
       - familienname
       - vorname
-      - vertrauensstufe
     properties:
       familienname:
         description: Familienname(n) der Person. Mehrere Familiennamen werden durch Leerzeichen separiert.

--- a/src/openapi/components-qs-Gruppe-basis-PATCH-request.yaml
+++ b/src/openapi/components-qs-Gruppe-basis-PATCH-request.yaml
@@ -43,7 +43,7 @@ properties:
       $ref: './components-code-Jahrgangsstufe.yaml'
   faecher:
     type: array
-    example: [{kennung: "DE"},{bezeichnung: "Erste Hilfe"}]
+    example: [{kennung: "DE", bezeichnung: "Erste Hilfe"}]
     items:
      oneOf:
         - $ref: './components-Gruppe-faecher-kennung.yaml'

--- a/src/openapi/components-qs-Gruppe-basis.yaml
+++ b/src/openapi/components-qs-Gruppe-basis.yaml
@@ -38,7 +38,7 @@ properties:
       $ref: './components-code-Jahrgangsstufe.yaml'
   faecher:
     type: array
-    example: [{kennung: "DE"},{bezeichnung: "Erste Hilfe"}]
+    example: [{kennung: "DE", bezeichnung: "Erste Hilfe"}]
     items:
      oneOf:
         - $ref: './components-Gruppe-faecher-kennung.yaml'

--- a/src/openapi/components-qs-Person-basis.yaml
+++ b/src/openapi/components-qs-Person-basis.yaml
@@ -2,6 +2,7 @@ type: object
 required:
   - name
   - auskunftssperre
+  - vertrauensstufe
 properties:
   referrer:
     description: Identifikations-ID einer Person. Wird vom Quellsystem vergeben und muss im Quellsystem eindeutig sein (z. B. eine einheitliche Personalnummer).
@@ -16,7 +17,6 @@ properties:
     required:
       - familienname
       - vorname
-      - vertrauensstufe
     properties:
       familienname:
         description: Familienname(n) der Person. Mehrere Familiennamen werden durch Leerzeichen separiert.


### PR DESCRIPTION
Beispiele zu Fächern mit Kennung und Bezeichnung angepasst, so dass sie dem Schema `faecher-kennung-bezeichnung` entsprechen. 
`Required` Tag zu Vertrauensstufen vom Namen auf die höhere Ebene (Person/Gruppe) verschoben.