### PR TITLE
#518 Lernperiode als Datentyp abbilden

### DIFF
--- a/docs/codelisten.md
+++ b/docs/codelisten.md
@@ -34,7 +34,7 @@ Lokale Codelisten können in unterschiedlichen Domänen voneinander abweichen, z
 Werden innerhalb dieser Schulconnex-Spezifikation konkrete Codewerte genannt, so sind diese als Beispiele zu verstehen und sind nicht verbindlich.
 
 Länderspezifische Codelisten sind [Beziehungen](#beziehungen-lokal), [Bildungsziel](#bildungsziel-lokal), [Fächerkanon](#fächerkanon-lokal), [Gruppenbereich](#gruppenbereich-lokal), [Gruppendifferenzierung](#gruppendifferenzierung-lokal), [Gruppenoption](#gruppenoption-lokal), 
-[Jahrgangsstufe](#jahrgangsstufe-lokal), [Lernperiode](#lernperiode-lokal) und [Lernperiodentyp](#lernperiodentyp-lokal).
+[Jahrgangsstufe](#jahrgangsstufe-lokal) und [Lernperiodentyp](#lernperiodentyp-lokal).
 
 
 ## Zukünftige Nutzung URI-basierter Codelisten
@@ -272,48 +272,6 @@ Code | Bezeichnung
 11 | Jahrgangsstufe 11
 12 | Jahrgangsstufe 12
 13 | Jahrgangsstufe 13
-
-### Lernperiode <span class="tag tag-cl-lokal">Lokal</span>
-
-Lernperioden dienen zur Festlegung des Beginns oder des Endes einer Kurslaufzeit.
-Der Code einer Lernperiode legt sowohl Anfangsdatum, Enddatum, auch den Typ (Schuljahr oder Schulhalbjahr) fest.
-
-Code | Bezeichnung | Beginn | Ende | Typ
---- | --- | --- | --- | ---
-2022 | Schuljahr 2022/23 | 2022-08-01 | 2023-07-31 | SJ
-2022-1 | 1. Halbj. 22/23 | 2022-08-01 | 2023-01-31 | HJ
-2022-2 | 2. Halbj. 22/23 | 2023-02-01 | 2023-07-31 | HJ
-2023 | Schuljahr 2023/24 | 2023-08-01 | 2024-07-31 | SJ
-2023-1 | 1. Halbj. 23/24 | 2023-08-01 | 2024-01-31 | HJ
-2023-2 | 2. Halbj. 23/24 | 2024-02-01 | 2024-07-31 | HJ
-2024 | Schuljahr 2024/25 | 2024-08-01 | 2025-07-31 | SJ
-2024-1 | 1. Halbj. 24/25 | 2024-08-01 | 2025-01-31 | HJ
-2024-2 | 2. Halbj. 24/25 | 2025-02-01 | 2025-07-31 | HJ
-2025 | Schuljahr 2025/26 | 2025-08-01 | 2026-07-31 | SJ
-2025-1 | 1. Halbj. 25/26 | 2025-08-01 | 2026-01-31 | HJ
-2025-2 | 2. Halbj. 25/26 | 2026-02-01 | 2026-07-31 | HJ
-2026 | Schuljahr 2026/27 | 2026-08-01 | 2027-07-31 | SJ
-2026-1 | 1. Halbj. 26/27 | 2026-08-01 | 2027-01-31 | HJ
-2026-2 | 2. Halbj. 26/27 | 2027-02-01 | 2027-07-31 | HJ
-2027 | Schuljahr 2027/28 | 2027-08-01 | 2028-07-31 | SJ
-2027-1 | 1. Halbj. 27/28 | 2027-08-01 | 2028-01-31 | HJ
-2027-2 | 2. Halbj. 27/28 | 2028-02-01 | 2028-07-31 | HJ
-2028 | Schuljahr 2028/29 | 2028-08-01 | 2029-07-31 | SJ
-2028-1 | 1. Halbj. 28/29 | 2028-08-01 | 2029-01-31 | HJ
-2028-2 | 2. Halbj. 28/29 | 2029-02-01 | 2029-07-31 | HJ
-2029 | Schuljahr 2029/30 | 2029-08-01 | 2030-07-31 | SJ
-2029-1 | 1. Halbj. 29/30 | 2029-08-01 | 2030-01-31 | HJ
-2029-2 | 2. Halbj. 29/30 | 2030-02-01 | 2030-07-31 | HJ
-2030 | Schuljahr 2030/31 | 2030-08-01 | 2031-07-31 | SJ
-2030-1 | 1. Halbj. 30/31 | 2030-08-01 | 2031-01-31 | HJ
-2030-2 | 2. Halbj. 30/31 | 2031-02-01 | 2031-07-31 | HJ
-2031 | Schuljahr 2031/32 | 2031-08-01 | 2032-07-31 | SJ
-2031-1 | 1. Halbj. 31/32 | 2031-08-01 | 2032-01-31 | HJ
-2031-2 | 2. Halbj. 31/32 | 2032-02-01 | 2032-07-31 | HJ
-2032 | Schuljahr 2032/33 | 2032-08-01 | 2033-07-31 | SJ
-2032-1 | 1. Halbj. 32/33 | 2032-08-01 | 2033-01-31 | HJ
-2032-2 | 2. Halbj. 32/33 | 2033-02-01 | 2033-07-31 | HJ
-
 
 ### Lernperiodentyp <span class="tag tag-cl-lokal">Lokal</span>
 

--- a/docs/datenmodell-qs/lernperiode.md
+++ b/docs/datenmodell-qs/lernperiode.md
@@ -7,14 +7,9 @@ tags:
 Eine Lernperiode beschreibt einen Zeitraum, in dem Gruppen von Organisationen angeboten werden können.
 Meist handelt es sich bei solchen Zeiträumen um gesetzlich vorgegebene Schuljahre oder Schulhalbjahre.
 
-Beim Datentyp Lernperiode handelt es sich nicht um über API-Calls veränderbare Daten, sondern Lernperioden
-werden über eine Codeliste bereitgestellt. Anders als bei den meisten anderen Codelisten handelt es sich bei
-Lernperioden jedoch nicht um eine einfache Code-/Werte-Liste, sondern um einen komplexen Datentyp, dessen
-Struktur in der folgenden Tabelle beschrieben ist.
-
 Attribut | Typ | Anzahl | Bemerkung
 --- | --- | --- | ---
-code | String (UTF-8) | 1 | Code der Lernperiode.
+code | String (UTF-8) | 1 | Code (ID) der Lernperiode.
 bezeichnung | String (UTF-8) | 1 | Bezeichnung der Lernperiode, beispielsweise „Schuljahr 2023/2024”.
 typ | String (UTF-8) | 1 | Typ der Lernperiode. Referenz auf einen Code der Codeliste *Lernperiodentyp*.
 beginn | Datum (siehe Abschnitt Datumsformat) | 1 | Datum, an dem die Lernperiode beginnt.

--- a/docs/english-api-notes/code-lists.md
+++ b/docs/english-api-notes/code-lists.md
@@ -30,7 +30,6 @@ Gruppendifferenzierung | An attribute to specify a specific level of a course. C
 Gruppenoption | Currently there are no options implemented.
 Gruppentyp | Classification of a group as „class”, „course“ or „other”. Classes are generally mandatory, while courses are often optional.
 Gruppenrolle | Similar to „Rolle”, but as this refers to roles in a group and not in an organisation, the options differ slightly. For example, groups cannot have system administrator, while organisations don't have group leaders.
-Lernperiode | A teaching period, usually a year or a semester (trimesters are rare in Germany). A more specific description of the structure of codes from this list is given in 13.1.9 Lernperiode.
 Lernperiodentyp | Type (essentially the length) of a teaching period Year or half-year
 Fächerkanon | Subjects that can be taught in a class or course. Such as biology, French or natural sciences.
 Bildungsziel | Type of school, based on likely qualification level upon leaving.

--- a/docs/english-api-notes/data-models.md
+++ b/docs/english-api-notes/data-models.md
@@ -155,9 +155,6 @@ revision | Revision number of the information. This is used to check on updates 
 A teaching period („Lernperiode”) is a time period in which organisations can offer groups.
 In most cases these periods are school years or semesters.
 
-Teaching periods are not modifiable via APIs, they are provided in the same manner as code lists.
-However, as they are not simple lists, but structured objects, their structure is described here.
-
 Attribute | Description
 --- | ---
 code | Code of the teaching period.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -699,7 +699,31 @@ const sidebars: SidebarsConfig = {
             },
           ],
         },
-      ],
+        {
+          type: 'category',
+          label: 'Lernperioden',
+          items: [
+            {
+              type: 'doc',
+              id: 'generated/openapi/quellsysteme/read-lernperioden',
+              label: '/lernperioden',
+              className: 'api-method get',
+            },
+            {
+              type: 'doc',
+              id: 'generated/openapi/quellsysteme/create-lernperiode',
+              label: '/lernperioden',
+              className: 'api-method post',
+            },
+            {
+              type: 'doc',
+              id: 'generated/openapi/quellsysteme/delete-lernperioden-code',
+              label: '/lernperioden/\u200B:code',
+              className: 'api-method delete',
+            },
+          ]
+          }
+          ],
     },
   ],
 

--- a/src/openapi/api-qs.yaml
+++ b/src/openapi/api-qs.yaml
@@ -30,6 +30,8 @@ tags:
     description: Verknüpfung von Personenkontext und Gruppe
   - name: Sichtfreigaben
     description: Regelt zeitliche Sichtfreigabe für Organisationen
+  - name: Lernperioden
+    description: Regelt zeitliche Geltungsdauer von Gruppen 
 paths:
   /personen:
     $ref: './paths-personen.yaml'
@@ -67,6 +69,10 @@ paths:
     $ref: './paths-gruppenzugehoerigkeiten-id.yaml'
   /sichtfreigaben/{id}:
     $ref: './paths-sichtfreigaben-id.yaml'
+  /lernperioden:
+    $ref: './paths-lernperioden.yaml'
+  /lernperioden/{code}:
+    $ref: './paths-lernperioden-code.yaml'
 components:
   securitySchemes:
     oAuthForServices:

--- a/src/openapi/components-Lernperiode.yaml
+++ b/src/openapi/components-Lernperiode.yaml
@@ -1,0 +1,30 @@
+description: Lernperiode.
+type: object
+properties:
+  code:
+    description: Die Kennung (Identifikations-ID) einer Lernperiode.
+    type: string
+    example: 214296d2-0f3e-4c92-a2bc-bccc6f2430d3
+  bezeichnung:
+    description:	Bezeichnung der Lernperiode.
+    type: string
+    example: Schuljahr 2023/2024
+  typ:
+    type: string
+    enum:
+     - SJ
+     - HJ
+    description: >
+      Typ der Lernperiode. Referenz auf einen Code der Codeliste Lernperiodentyp.
+      * SJ Schuljahr
+      * HJ Halbjahr
+    example: SJ
+  beginn:
+    description:	Datum, an dem die Lernperiode beginnt.
+    type: string
+    example: 2027-08-01
+  ende:
+    description:	Datum, an dem die Lernperiode endet.
+    type: string
+    example: 2028-07-31
+

--- a/src/openapi/components-code-Lernperiode.yaml
+++ b/src/openapi/components-code-Lernperiode.yaml
@@ -1,22 +1,2 @@
 type: string
-enum:
-  - "2022"
-  - "2022-1"
-  - "2022-2"
-  - "2023"
-  - "2023-1"
-  - "2023-2"
-  - "2024"
-  - "2024-1"
-  - "2024-2"
-  - "2025"
-  - "2025-1"
-  - "2025-2"
-  - "2026"
-  - "2026-1"
-  - "2026-2"
-  - "2027"
-  - "2027-1"
-  - "2027-2"
-description: |
-  Aus Codeliste [Lernperiode](../../../codelisten#lernperiode)
+description: Code (ID) der Lernperiode

--- a/src/openapi/components-qs-Lernperiode-POST-request.yaml
+++ b/src/openapi/components-qs-Lernperiode-POST-request.yaml
@@ -1,0 +1,31 @@
+description: Lernperiode.
+type: object
+required:
+  - bezeichnung
+  - typ
+  - beginn
+  - ende
+properties:
+  bezeichnung:
+    description:	Bezeichnung der Lernperiode.
+    type: string
+    example: Schuljahr 2023/2024
+  typ:
+    type: string
+    enum:
+     - SJ
+     - HJ
+    description: >
+      Typ der Lernperiode. Referenz auf einen Code der Codeliste Lernperiodentyp.
+      * SJ Schuljahr
+      * HJ Halbjahr
+    example: SJ
+  beginn:
+    description:	Datum, an dem die Lernperiode beginnt.
+    type: string
+    example: 2027-08-01
+  ende:
+    description:	Datum, an dem die Lernperiode endet.
+    type: string
+    example: 2028-07-31
+

--- a/src/openapi/components-qs-Lernperiode.yaml
+++ b/src/openapi/components-qs-Lernperiode.yaml
@@ -1,0 +1,30 @@
+description: Lernperiode.
+type: object
+properties:
+  code:
+    description: Die Kennung (Identifikations-ID) einer Lernperiode.
+    type: string
+    example: 214296d2-0f3e-4c92-a2bc-bccc6f2430d3
+  bezeichnung:
+    description:	Bezeichnung der Lernperiode.
+    type: string
+    example: Schuljahr 2023/2024
+  typ:
+    type: string
+    enum:
+     - SJ
+     - HJ
+    description: >
+      Typ der Lernperiode. Referenz auf einen Code der Codeliste Lernperiodentyp.
+      * SJ Schuljahr
+      * HJ Halbjahr
+    example: SJ
+  beginn:
+    description:	Datum, an dem die Lernperiode beginnt.
+    type: string
+    example: 2027-08-01
+  ende:
+    description:	Datum, an dem die Lernperiode endet.
+    type: string
+    example: 2028-07-31
+

--- a/src/openapi/paths-lernperioden-code.yaml
+++ b/src/openapi/paths-lernperioden-code.yaml
@@ -24,7 +24,7 @@ delete:
 
     Ein DELETE muss mit einer HTTP-DELETE Anfrage erfolgen. 
 
-    Diese API ist häufig nur als interne API für den Betreiber einens Schulconnex-Servers 
+    Diese API ist häufig nur als interne API für den Betreiber eines Schulconnex-Servers 
     zur Durchführung administrativer Funktionen verfügbar.
 
     Siehe auch das Datenmodell zu [`Lernperiode`](../../../datenmodell-qs/lernperiode).

--- a/src/openapi/paths-lernperioden-code.yaml
+++ b/src/openapi/paths-lernperioden-code.yaml
@@ -1,0 +1,77 @@
+delete:
+  tags:
+    - Lernperioden
+  operationId: deleteLernperiodenCode
+  security:
+    - oAuthForServices: []
+  summary: Lernperioden löschen
+  description: |
+    Die Schnittstelle `/lernperioden/{lernperiode.code}` erlaubt es, Lernperioden zu löschen.
+    Der Pfad-Parameter `lernperiode.code` bezieht sich auf die ID (Code) der Lernperiode.
+
+    Eine solche Löschung ist ein Ausnahmefall. 
+
+    Lernperioden werden von Quellsystemen und Diensten benutzt, um die zeitliche Geltungsdauer
+    von Gruppen zu beschreiben. Eine Löschung einer Lernperiode kann daher Auswirkungen
+    auf die Geltungsdauer von Gruppen haben, welche mit der Lernperiode verknüpft sind.
+
+    In den meisten Fällen ist es sinnvoller bei der Veränderung der Laufzeiten von Lernperioden
+    eine neue, revidierte Lernperiode anzulegen und es Client-Systemen zu überlassen, ob sie
+    die alte Lernperiode beibehalten oder auf eine neue Lernperiode wechseln wollen.
+
+    Eine Löschung ist nur dann sinnvoll und unproblematisch, wenn in keiner Gruppe eine
+    Referenz auf diese Lernperiode vorhanden ist. 
+
+    Ein DELETE muss mit einer HTTP-DELETE Anfrage erfolgen. 
+
+    Diese API ist häufig nur als interne API für den Betreiber einens Schulconnex-Servers 
+    zur Durchführung administrativer Funktionen verfügbar.
+
+    Siehe auch das Datenmodell zu [`Lernperiode`](../../../datenmodell-qs/lernperiode).
+
+  parameters:
+    - in: path
+      name: code
+      schema:
+        type: string
+        example: 1fd95f6f-bc28-408b-8e03-41972b414a07
+      required: true
+      description: Der Pfad-Parameter bezieht sich auf die Code-ID der Lernperiode.
+  responses:
+    '204':
+      description: |
+        No Content
+
+        Bei einer erfolgreichen Ausführung der Löschanfrage wird es keine Antwort-Nutzdaten (Response Payload) geben.
+    '304':
+      description: Not Modified
+    '400':
+      description: |
+        Bad Request
+
+        Siehe [Fehlerbehandlung](../../../schnittstellendefinition/http-statuscodes-qs)
+    '401':
+      description: |
+        Unauthorized
+
+        Siehe [Fehlerbehandlung](../../../schnittstellendefinition/http-statuscodes-qs)
+    '403':
+      description: |
+        Forbidden
+
+        Siehe [Fehlerbehandlung](../../../schnittstellendefinition/http-statuscodes-qs)
+    '404':
+      description: |
+        Not found
+
+        Siehe [Fehlerbehandlung](../../../schnittstellendefinition/http-statuscodes-qs)
+    '405':
+      description: |
+        Method not allowed
+
+        Siehe [Fehlerbehandlung](../../../schnittstellendefinition/http-statuscodes-qs)
+    '409':
+      description: |
+        Conflict
+
+        Siehe [Fehlerbehandlung](../../../schnittstellendefinition/http-statuscodes-qs)

--- a/src/openapi/paths-lernperioden.yaml
+++ b/src/openapi/paths-lernperioden.yaml
@@ -1,0 +1,113 @@
+get:
+  tags:
+    - Lernperioden
+  operationId: readLernperioden
+  security:
+    - oAuthForServices: []
+  summary: Auflistung von Lernperioden
+  description: |
+    Die Schnittstelle `/lernperioden` ermöglich die Auflistung von Lernperioden.
+
+    Ein READ muss mit einer HTTP-GET Anfrage erfolgen. Die Antwort-Nutzdaten
+    (Response Payload) beinhalten ein Array von JSON-Objekten vom Datentyp Lernperiode.
+
+    Siehe auch Datenmodell [`Lernperiode`](../../../datenmodell-qs/lernperiode).
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+             $ref: './components-Lernperiode.yaml'
+    '400':
+      description: |
+        Bad Request
+
+        Siehe [Fehlerbehandlung](../../../schnittstellendefinition/http-statuscodes-qs)
+    '401':
+      description: |
+        Unauthorized
+
+        Siehe [Fehlerbehandlung](../../../schnittstellendefinition/http-statuscodes-qs)
+    '403':
+      description: |
+        Forbidden
+
+        Siehe [Fehlerbehandlung](../../../schnittstellendefinition/http-statuscodes-qs)
+    '404':
+      description: |
+        Not found
+
+        Siehe [Fehlerbehandlung](../../../schnittstellendefinition/http-statuscodes-qs)
+    '405':
+      description: |
+        Method not allowed
+
+        Siehe [Fehlerbehandlung](../../../schnittstellendefinition/http-statuscodes-qs)
+post:
+  tags:
+    - Lernperioden
+  operationId: createLernperiode
+  security:
+    - oAuthForServices: []
+  summary: Erstellen einer Lernperiode
+  description: |
+    Mittels dieser Schnittstelle wird ein neuer Datensatz „Lernperiode” erstellt.
+
+    Ein CREATE zum Erstellen von Lernperioden muss mit HTTP-POST auf die API `/lernperioden`
+    erfolgen. Die Anfrage-Nutzdaten (Request Payload) beinhalten ein JSON-Objekt des
+    Datentyps Lernperiode.
+
+    Siehe auch das Datenmodell zu [`Lernperiode`](../../../datenmodell-qs/lernperiode).
+
+    Der Lernperioden-Code wird vom Schulconnex-Service vergeben und hinzugefügt.
+
+    Bei einer erfolgreichen Anforderung zum Erstellen einer Lernperiode wird diese Anforderung
+    mit einer Repräsentation der Lernperiode in den Antwort-Nutzdaten (Response Payload) und
+    dem HTTP-Statuscode 201 quittiert.
+    
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: './components-qs-Lernperiode-POST-request.yaml'
+  responses:
+    '201':
+      description: OK
+      content:
+        application/json:
+          schema:
+           $ref: './components-qs-Lernperiode.yaml'
+    '400':
+      description: |
+        Bad Request
+
+        Siehe [Fehlerbehandlung](../../../schnittstellendefinition/http-statuscodes-qs)
+    '401':
+      description: |
+        Unauthorized
+
+        Siehe [Fehlerbehandlung](../../../schnittstellendefinition/http-statuscodes-qs)
+    '403':
+      description: |
+        Forbidden
+
+        Siehe [Fehlerbehandlung](../../../schnittstellendefinition/http-statuscodes-qs)
+    '404':
+      description: |
+        Not found
+
+        Siehe [Fehlerbehandlung](../../../schnittstellendefinition/http-statuscodes-qs)
+    '405':
+      description: |
+        Method not allowed
+
+        Siehe [Fehlerbehandlung](../../../schnittstellendefinition/http-statuscodes-qs)
+    '409':
+      description: |
+        Conflict
+
+        Siehe [Fehlerbehandlung](../../../schnittstellendefinition/http-statuscodes-qs)


### PR DESCRIPTION
Lernperiode als Codeliste entfernt.
Lernperiode als Datenmodel beibehalten, aber Referenz auf Codeliste entfernt. 
CREATE/READ/DELETE APIs für Lernperioden definiert. 
Anpassungen des englischen Textes.

HINWEIS:
Um in den 1.x Versionen kompatibel zu bleiben, wird als Attributname zur Referenzierung von Lernperioden die Bezeichnung `code` beibehalten. Sinnvoll wäre es aber ab 2.0 als Attribut (wie bei allen anderen Datentypen) `id` (bzw. wo andere IDs referenziert werden `lpod` oder ähnlich) zu nutzen.