### PR TITLE
#561 Schulconnex im Systemkontext

### DIFF
--- a/docs/praxisleitfaden/ablauf-synchronisation-systemkontext.md
+++ b/docs/praxisleitfaden/ablauf-synchronisation-systemkontext.md
@@ -1,0 +1,64 @@
+---
+title: Ausnahmefall -  Synchronisation im Systemkontext
+tags:
+- Informativ
+---
+
+# Synchronisation zwischen Schulconnex-Servern
+
+In seltenen Fällen kann es gewünscht sein, eine Vollsynchronisation zwischen zwei Schulconnex-Servern durchzuführen. Hierfür müssen Daten auch organisationsübergreifend gelesen werden können.
+
+Es bleibt dem Betreiber eines Schulconnex-Servers freigestellt neben den üblichen organisationsspezifischen Access-Token auch organisationsübergreifende System-Token bereitzustellen.
+
+Diese erlauben es, über `GET /personen`, `GET /personenkontexte`, `GET/personenkontexte/:id/beziehungen`, `GET /personenkontexte/:id/sichtfreigaben`, `GET /gruppen` und `GET /gruppenzugehörigkeiten` alle Daten in den jeweiligen Datenmodell auszulesen.
+Entsprechend können mit `GET /organisationen` auch alle Organisationen und mit `GET /organisationen/:id/organisationsbeziehungen` auch alle Organisationsbeziehungen ausgelesen werden. Dieses ist aber normalerweise allen Organisationen gestattet und erfordert kein System-Token.
+
+## Auslesen eines Schulconnex-Servers
+
+Beim Arbeiten im Systemkontext sind beim Auslesen der Daten aus einem Schulconnex-Servers folgende Punkte zu beachten:
+*	Schulconnex-Server haben keine Locking-Funktionalität.
+    *	Es gibt keine Garantie, dass mehrere aufeinanderfolgende Abfragen konsistente Rückgabewerte liefern. 
+    * So kann beispielsweise bei der Abfrage der Gruppenzugehörigkeiten die ID eines Personenkontexts geliefert werden, die bei der Abfrage der Personenkontexte noch nicht erstellt wurde.
+    * Umgekehrt kann es geschehen, dass ein Datensatz in einer Abfrage noch über eine ID referenziert wird, dieser Datensatz bei der Abfrage der entsprechenden Daten jedoch schon gelöscht ist. 
+    *	Ein System zum Abgleich zweier Server muss solche Inkonsistenzen erkennen und damit umgehen können, beispielsweise durch erneute Einzelabfrage der beiden in Konflikt stehenden Datensätze.
+*	Die Pseudo-IDs für Dienste können nicht synchronisiert werden.
+    *	Es bleibt jedem Schulconnex-Server überlassen, wie die pseudonymen IDs für Dienste erzeigt werden. Dieses kann dynamisch geschehen, beispielsweise durch Encrypten der ID mit einem dienstspezifischen Schlüssel, oder auch zufällig beim ersten Zugriff auf einen Datensatz durch einen Dienst mit anschließender Speicherung in einer internen Datenbank.
+    *	Diese Informationen stehen für Abfragen über die API nicht zur Verfügung. 
+    *	Durch Synchronisation zweier Schulconnex-Server kann zwar für Quellsysteme ein im Verhalten nahezu identischer Server erstellt werden, nicht jedoch für Dienste.
+*	Interne Server-Zustände können nicht ausgelesen werden.
+    *	Insbesondere kann nicht ausgelesen werden, ob und welche Daten bereits von Diensten abgefragt wurden.
+    *	Nur die regulär für Organisationen auslesbaren Daten können abgefragt werden.
+    *	Abfragen im Systemkontext erlauben ausschließlich ein organisationsübergreifendes Auslesen von Daten. Sie erlauben keinen Zugriff auf zusätzliche Informationen.
+    *	Bei Sichtfreigaben sollten nur die erstellten Sichtfreigaben ausgelesen werden
+*	Personen und Personenkontexte, welche über Sichtfreigaben für mehrere Organisationen sichtbar sind, können eventuell, je nach Auslesevorgang, bei mehreren Organisationen gelistet werden.
+    *	Es sollten daher nur die Personen, Personenkontexte und Sichtfreigaben der bereitstellenden Organisation abgefragt werden, nicht die der Organisation, für die eine Sichtfreigabe erfolgt ist.
+    *	Zum Abfragen der Personen und Personenkontexte ohne fremde Sichtfreigaben ist die Filteroption `sichtfreigabe=nein` vorgesehen.
+    *	Bei der Abfrage der Sichtfreigaben sind die Filteroptionen `ausgehend=ja` und `eingehend=nein` zu nutzen. 
+
+
+## Übertragung auf einen zweiten Server
+
+
+In den meisten Szenarien bei denen im Systemkontext gearbeitet wird, ist anzunehmen, dass das Ziel-System, ob Schulconnex-Server oder anderer Server, vom Abfragenden selbst betrieben wird und daher verändert werden kann.
+
+Grundsätzlich sind vier Szenarien zu unterscheiden.
+
+### 1. Nutzung der regulären Schulconnex-APIs
+Hierbei werden die regulären POST-APIs zum Erstellen der jeweiligen Datensätze (Personendatensätze, Personenkontexte, Beziehungen, Gruppen, Gruppenbeziehungen, Sichtfreigaben, Organisationen und Organisationsbeziehungen) genutzt. 
+
+Nach jedem Erstellen eines Datensatzes ist die erzeugte ID auszulesen und ein Mapping zwischen Quell-ID und Ziel-ID zu erstellen. Bei der Erzeugung von Datensätzen, welche andere Datensätze referenzieren, ist die ID entsprechend anzupassen.
+
+Diese Vorgehensweise ist nur selten sinnvoll, da im Normallfall die Organisations-ID aus dem Access-Token übernommen wird und damit für alle Datensätze, unabhängig vom Wert im Quell-Server, gleich ist. Ähnliches gilt auch für das Mandanten-Attribut.
+
+### 2. Nutzung der Schulconnex-APIs mit schreibaren Organisations- und Mandanten-Attributen
+Hierbei wird vorgegangen wie im vorhergehenden Beispiel, es werden jedoch vom Server Varianten der POST-APIs bereitgestellt, bei denen die Attribute organisation und mandant nicht vom Server vergeben werden, sondern als REQUIRED Attribute im BODY mit angegeben werden können. 
+
+Es ist empfehlenswert solche veränderten API-Endpunkte gesondert zu sichern und nur lokal zugänglich zu machen.
+
+### 3. Nutzung der Schulconnex-APIs mit schreibaren ID-, Organisations- und Mandanten-Attributen
+Hierbei handelt es sich um eine Erweiterung des vorhergehenden Beispiels, allerdings muss bei dieser Veränderung der APIs auch das Attribut ID als ‚REQUIRED‘ definiert sein. Über eine solche API können die IDs des Quell-Servers direkt übernommen werden. Ein Mapping auf neue IDs ist nicht notwendig.
+
+Es ist jedoch zu beachten, dass Schulconnex nicht festlegt, wie IDs in einem Schulconnex-Server erzeugt und verwaltet werden. Nutzt beispielsweise der Quell-Server dafür UUIDs, das Ziel-System jedoch intern numerische Werte, so ist eine direkte Kopie der existierenden IDs auch über eine veränderte API nicht möglich.
+
+### 4. Direktes Schreiben in die eigene Datenbank
+Wenn ein direkter Zugriff auf die internen Strukturen eines Schulconnex-Servers möglich ist, dann ist es oft einfacher die ausgelesenen Daten direkt in die Datenbank des Zielsystems zu schreiben, ohne dabei über die Schulconnex-APIs zu gehen. 

--- a/docs/praxisleitfaden/ablauf-synchronisation-systemkontext.md
+++ b/docs/praxisleitfaden/ablauf-synchronisation-systemkontext.md
@@ -33,7 +33,7 @@ Beim Arbeiten im Systemkontext sind beim Auslesen der Daten aus einem Schulconne
 *	Personen und Personenkontexte, welche über Sichtfreigaben für mehrere Organisationen sichtbar sind, können eventuell, je nach Auslesevorgang, bei mehreren Organisationen gelistet werden.
     *	Es sollten daher nur die Personen, Personenkontexte und Sichtfreigaben der bereitstellenden Organisation abgefragt werden, nicht die der Organisation, für die eine Sichtfreigabe erfolgt ist.
     *	Zum Abfragen der Personen und Personenkontexte ohne fremde Sichtfreigaben ist die Filteroption `sichtfreigabe=nein` vorgesehen.
-    *	Bei der Abfrage der Sichtfreigaben sind die Filteroptionen `ausgehend=ja` und `eingehend=nein` zu nutzen. 
+    *	Bei der Abfrage der Sichtfreigaben sind die Filteroptionen `erteilt=ja` und `erhalten=nein` zu nutzen. 
 
 
 ## Übertragung auf einen zweiten Server

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -281,6 +281,7 @@ const sidebars: SidebarsConfig = {
       },
       items: [
         'praxisleitfaden/ablauf-synchronisation',
+        'praxisleitfaden/ablauf-synchronisation-systemkontext',
         'praxisleitfaden/ablauf-schuljahrwechsel',
         'praxisleitfaden/rolle-in-organisation',
         'praxisleitfaden/ablauf-löschen',

--- a/src/openapi/paths-personenkontexte-id-sichtfreigaben.yaml
+++ b/src/openapi/paths-personenkontexte-id-sichtfreigaben.yaml
@@ -105,8 +105,8 @@ get:
    
    Filter | Typ | Beschreibung
     --- | --- | ---
-    `ausgehend`   | String (Boolean) | listet alle Sichtfreigaben auf, welche von der Organisation, zu welcher der Personenkontext gehört, für andere Organisationen erteilt wurden. Der Defaultwert ist `ja`.
-    `eingehend` | String (Boolean) | listet alle Sichtfreigaben auf, welche von einer anderen Organisation für die eigene Organisation erteilt wurden. Der Defaultwert ist `ja`.
+    `erteilt`   | String (Boolean) | listet alle Sichtfreigaben auf, welche von der Organisation, zu welcher der Personenkontext gehört, für andere Organisationen erteilt wurden. Der Defaultwert ist `ja`.
+    `erhalten` | String (Boolean) | listet alle Sichtfreigaben auf, welche die eigene Organisation von einer anderen Organisation erhalten hat. Der Defaultwert ist `ja`.
     
    Ein READ zum Abfragen der Sichtfreigaben per `personenkontext.id` muss mit HTTP-GET auf die API `/personenkontexte/{personenkontext.id}/sichtfreigaben` erfolgen.
 
@@ -120,14 +120,14 @@ get:
       required: true
       description: Der Pfad-Parameter bezieht sich auf die ID des Personenkontexts.
     - in: query
-      name: ausgehend
+      name: erteilt
       schema:
         type: string
         enum:
           - Ja
           - Nein
     - in: query
-      name: eingehend
+      name: erhalten
       schema:
         type: string
         enum:

--- a/src/openapi/paths-personenkontexte-id-sichtfreigaben.yaml
+++ b/src/openapi/paths-personenkontexte-id-sichtfreigaben.yaml
@@ -96,10 +96,18 @@ get:
    Dieser Schnittstellenendpunkt gibt eine Liste der existierenden Sichtfreigaben eines
    Personenkontexts zurück.
    
-   Es werden sowohl die Sichtfreigaben für einen Personenkontext zurückgegeben, welcher der abfragenden Organisation
+   Ohne weiteres Filtern werden sowohl die Sichtfreigaben für einen Personenkontext zurückgegeben, welcher der abfragenden Organisation
    zugeordnet sind (Attribut `personenkontext.organisation`), als auch für einen Personenkontext, für den
    einer Organisation eine Sichtfreigabe erteilt wurde. 
 
+   Es können über einen Filter jedoch auch nur die von der eigenen Organisation freigegebenen Sichtfreigaben 
+   oder nur die Sichtfreigaben, welche von anderen Organisationen für den eigenen Personenkontext erteilt wurden, zurückgegeben werden.
+   
+   Filter | Typ | Beschreibung
+    --- | --- | ---
+    `ausgehend`   | String (Boolean) | listet alle Sichtfreigaben auf, welche von der Organisation, zu welcher der Personenkontext gehört, für andere Organisationen erteilt wurden. Der Defaultwert ist `ja`.
+    `eingehend` | String (Boolean) | listet alle Sichtfreigaben auf, welche von einer anderen Organisation für die eigene Organisation erteilt wurden. Der Defaultwert ist `ja`.
+    
    Ein READ zum Abfragen der Sichtfreigaben per `personenkontext.id` muss mit HTTP-GET auf die API `/personenkontexte/{personenkontext.id}/sichtfreigaben` erfolgen.
 
    Die Antwort-Nutzdaten (Response Payload) beinhalten ein JSON-Objekt mit einem Array des Datentyps Beziehung.
@@ -111,6 +119,20 @@ get:
         example: 4d0f579c-0b9a-4d3a-b484-87b3bee8a2ad
       required: true
       description: Der Pfad-Parameter bezieht sich auf die ID des Personenkontexts.
+    - in: query
+      name: ausgehend
+      schema:
+        type: string
+        enum:
+          - Ja
+          - Nein
+    - in: query
+      name: eingehend
+      schema:
+        type: string
+        enum:
+          - Ja
+          - Nein
   responses:
     '200':
       description: OK


### PR DESCRIPTION
Filter bei den Sichtfreigaben eingefügt, so dass auch nur erteilte oder nur erhaltene Sichtfreigaben ausgegeben werden.

Sichergestellt, dass bei den GET APIs immer davon die Rede ist, dass Daten geliefert werden, die gelesen werden dürfen (statt nur Daten, die der eigenen Organisation 'gehören' oder freigegeben wurden).

Praxisleitfaden zum Arbeiten im Systemkontext
- Was ist beim Lesevorgang zu beachten?
- Was geht mit den existierenden APIs?
- Wie können APIs modifiziert werden, um Daten (insbesondere die Organisations-Information) sinnvoll zu kopieren