### PR TITLE
#601 Attribute mit Wert null werden dürfen nicht geliefert werden

### DIFF
--- a/docs/allgemeines-dienste.md
+++ b/docs/allgemeines-dienste.md
@@ -26,3 +26,7 @@ ihnen gehaltenen Daten mit den Daten des Schulconnex-Services, ohne dass sich di
 nutzenden Personen aktiv anmelden müssen. Der Zugriff erfolgt mit einem Access-Token,
 den der Authentifizierungsserver und Autorisierungsserver für den Dienst ausstellt. Dieser
 Sicherheitskontext wird aktuell zum periodischen Abgleich von gelöschten Daten verwendet.
+
+import Text from './allgemeines-leere-attribute.md';
+
+<Text />

--- a/docs/allgemeines-leere-attribute.md
+++ b/docs/allgemeines-leere-attribute.md
@@ -1,6 +1,8 @@
 ## Leere Attribute
 
-Attribute, für die kein Wert gespeichert ist, unabhängig davon, ob ein Client im Prinzip auf dieses Attribut zugreifen kann, werden von Schulconnex-Servern nicht ausgeliefert. Das gilt sowohl für einfache Attribute als auch für komplexe Objekt, wenn alle enthaltenen Attribute leer sind.
+Attribute, für die kein Wert gespeichert ist, unabhängig davon, ob ein Client im Prinzip auf dieses Attribut zugreifen kann, dürfen von Schulconnex-Servern nicht ausgeliefert werden. Das gilt sowohl für einfache Attribute als auch für komplexe Objekt, wenn alle enthaltenen, für einen Client lesbaren, Attribute leer sind.
+
+Ein Attribut hat dann keinen Wert, wenn dieser nie gesetzt wurde und in der Spezifikation kein Default-Wert definiert ist, oder wenn ein vorhandener Wert gelöscht oder bei einem PUT oder PATCH auf `null` gesetzt wurde.
 
 Ist, beispielsweise, zur Geburt einer Person nur der Ort und nicht das Datum gesetzt, so liefert der Server in der Antwort auch nur:
 ```
@@ -9,3 +11,5 @@ Ist, beispielsweise, zur Geburt einer Person nur der Ort und nicht das Datum ges
     }
 ```
 Ist auch der Geburtsort nicht gesetzt, so wird das Objekt `geburt` in der Antwort nicht geliefert
+
+Hierdurch sollen Inkonsistenzen im Verhalten unterschiedlicher Schulconnex-Server vermieden werden und verhindert werden, dass Client-Syteme implizit Rückschlüsse auf für diese nicht freigegebene Attribute ziehen können.

--- a/docs/allgemeines-leere-attribute.md
+++ b/docs/allgemeines-leere-attribute.md
@@ -1,0 +1,11 @@
+## Leere Attribute
+
+Attribute, für die kein Wert gespeichert ist, unabhängig davon, ob ein Client im Prinzip auf dieses Attribut zugreifen kann, werden von Schulconnex-Servern nicht ausgeliefert. Das gilt sowohl für einfache Attribute als auch für komplexe Objekt, wenn alle enthaltenen Attribute leer sind.
+
+Ist, beispielsweise, zur Geburt einer Person nur der Ort und nicht das Datum gesetzt, so liefert der Server in der Antwort auch nur:
+```
+"geburt": {
+      "geburtsort": "Berlin, Deutschland"
+    }
+```
+Ist auch der Geburtsort nicht gesetzt, so wird das Objekt `geburt` in der Antwort nicht geliefert

--- a/docs/allgemeines-qs.md
+++ b/docs/allgemeines-qs.md
@@ -9,3 +9,7 @@ durch Quellsysteme nicht verändert werden dürfen, beispielsweise die Mandanten
 können diese Attribute oft weggelassen werden (genaueres ist bei den entsprechenden Funktionen angegeben).
 Werden die Attribute bei der UPDATE-Operation angegeben, so müssen sie allerdings dem vorher ausgelesenen
 Wert entsprechen. Bei einer Abweichung wird eine Fehlermeldung ausgegeben.
+
+import Text from './allgemeines-leere-attribute.md';
+
+<Text />


### PR DESCRIPTION
Sowohl bei Diensten als auch bei Quellsystemen ist jetzt im Absatz "Allgemeines" ein Text mit aufgenommen, der beschreibt, dass leeren Attribute und Objekte vom Server nicht geliefert werden.