### PR TITLE
#602 PATCH und DELETE bei HTTP Request auflisten.

### DIFF
--- a/docs/schnittstellen/schnittstellen.md
+++ b/docs/schnittstellen/schnittstellen.md
@@ -1,5 +1,3 @@
-# Nutzung der REST-API
-
 Die von Schulconnex-Servern bereitgestellten Endpunkte sind als REST-API realisiert.
 
 Allgemein erfolgen Zugriffe auf Ressourcen über die Endpunkte mit Hilfe von CRUD-Operationen

--- a/docs/schnittstellendefinition/schnittstellendefinition-dienste.md
+++ b/docs/schnittstellendefinition/schnittstellendefinition-dienste.md
@@ -3,5 +3,7 @@ title: ''
 ---
 
 import Text from './schnittstellendefinition.md';
+import Rueckgaben from './schnittstellendefinition-rueckgaben.md';
 
 <Text />
+<Rueckgaben/>

--- a/docs/schnittstellendefinition/schnittstellendefinition-qs.md
+++ b/docs/schnittstellendefinition/schnittstellendefinition-qs.md
@@ -3,5 +3,28 @@ title: ''
 ---
 
 import Text from './schnittstellendefinition.md';
+import Rueckgaben from './schnittstellendefinition-rueckgaben.md';
 
 <Text />
+
+#### POST
+
+Per `POST` können große Datenmengen zum Webserver gesendet werden. Dabei werden
+die Parameter nicht in die URL, sondern in den HTTP-Body geschrieben.
+`POST` wird oft benutzt, um mehrere Daten gleichzeitig zu senden oder um
+Entitäten zu erstellen.
+
+#### PUT
+
+`PUT` funktioniert ähnlich wie `POST` und dient dazu, bereits existierende Entitäten zu verändern. Dabei wird eine Entität vollständig mit den Daten im `PUT` überschrieben.
+
+#### PATCH
+
+`PATCH` funktioniert ähnlich wie `PUT` und dient dazu, Entitäten auf dem Webserver zu verändern. Anders als bei `PUT` werden hier nur die Daten verändert, welche im Request angegeben
+wurden. Andere Daten bleiben unverändert erhalten. 
+
+#### DELETE
+
+Mit einem `DELETE` werden Entitäten auf dem Webserver gelöscht.
+
+<Rueckgaben/>

--- a/docs/schnittstellendefinition/schnittstellendefinition-rueckgaben.md
+++ b/docs/schnittstellendefinition/schnittstellendefinition-rueckgaben.md
@@ -1,0 +1,11 @@
+###	Standard-Rückgaben (Default Responses)
+
+Nachdem der Webserver eine Anfrage erhalten und interpretiert hat, wird mit einer
+HTTP-Response geantwortet. Eine HTTP-Response besitzt einen HTTP-Status-Code.
+Die erste Ziffer des Status-Codes gibt die Kategorie der HTTP-Response an:
+
+- `1xx`: Informative Antworten
+- `2xx`: Erfolg
+- `3xx`: Weiterleitung
+- `4xx`: Client-Fehler
+- `5xx`: Server-Fehler

--- a/docs/schnittstellendefinition/schnittstellendefinition.md
+++ b/docs/schnittstellendefinition/schnittstellendefinition.md
@@ -16,27 +16,3 @@ gespeicherte Ressourcen beziehungsweise Entitäten abzurufen und/oder zu bearbei
 `GET` ruft eine oder mehrere Entitäten/Ressourcen vollständig oder teilweise ab.
 Der `GET`-Anfrage können zusätzliche Informationen mitgegeben werden, die der Webserver
 verarbeiten soll. Diese URL-Parameter werden an die URL angehängt.
-
-#### POST
-
-Per `POST` können große Datenmengen zum Webserver gesendet werden. Dabei werden
-die Parameter nicht in die URL, sondern in den HTTP-Body geschrieben.
-`POST` wird oft benutzt, um mehrere Daten gleichzeitig zu senden oder um
-Entitäten zu erstellen.
-
-#### PUT
-
-PUT funktioniert ähnlich wie `POST` und dient dazu, Dateien auf dem Webserver abzulegen
-beziehungsweise bereits existierende Entitäten zu verändern.
-
-###	Standard-Rückgaben (Default Responses)
-
-Nachdem der Webserver eine Anfrage erhalten und interpretiert hat, wird mit einer
-HTTP-Response geantwortet. Eine HTTP-Response besitzt einen HTTP-Status-Code.
-Die erste Ziffer des Status-Codes gibt die Kategorie der HTTP-Response an:
-
-- `1xx`: Informative Antworten
-- `2xx`: Erfolg
-- `3xx`: Weiterleitung
-- `4xx`: Client-Fehler
-- `5xx`: Server-Fehler


### PR DESCRIPTION
Bei der Beschreibung der Standard-Anfragen im Abschnitt Schnittstellendefinition wurden bisher, sowohl für Dienste als auch Quellsysteme, GET, POST und PUT gelistet. Darüber hinaus sind aber auch PATCH und DELETE möglich. Da POST und PUT für Dienste nicht zulässig sind, wurden die Seiten jetzt so umgestellt, dass die Texte zu GET und zu den Rueckgabewerten für beide Fälle inkludiert, auf der Quellsystem-Seite jedoch zusätzlich POST, PUT, PATCH und DELETE beschrieben werden.

Zusätzlich wurde auf der Schnittstellen-Seite noch der Titel "Nutzung der REST-API" entfernt, da dieser sowohl auf der aufrufenden als auch auf der inkludierten Seite vorhanden war und daher auf der Schulconnex-Seite doppelt dargestellt wurde.