### PR TITLE
#599 Falsche Attribute nullable bei den neuen PATCH-Attributen

### DIFF
--- a/src/openapi/components-qs-Gruppe-basis-PATCH-request.yaml
+++ b/src/openapi/components-qs-Gruppe-basis-PATCH-request.yaml
@@ -1,5 +1,20 @@
+
 type: object
+required:
+  - revision
 properties:
+  id:
+    description: ID der Gruppe.
+    type: string
+    example: b3201d00-f21f-4986-a39d-02a09c8da26c
+  mandant:
+    description: ID des Mandanten.
+    type: string
+  orgid:
+    description: ID der Organisation.
+    type: string
+    example: 9b3f36ad-9d15-49f9-9660-6cf9746ba446
+    nullable: true
   referrer:
     description: ID der Gruppe im Quellsystem.
     type: string
@@ -76,3 +91,6 @@ properties:
       - $ref: './components-Laufzeit-vonlernperiode-PATCH.yaml'
       - $ref: './components-Laufzeit-bis-PATCH.yaml'
       - $ref: './components-Laufzeit-bislernperiode-PATCH.yaml'
+  revision:
+    description: Revision der Gruppe.
+    type: string

--- a/src/openapi/components-qs-Personenkontext-PATCH-request.yaml
+++ b/src/openapi/components-qs-Personenkontext-PATCH-request.yaml
@@ -12,7 +12,6 @@ properties:
     example: 58f45270-8e54-40c6-a212-980307fc19be
   organisation:
     type: object
-    nullable: true
     properties:
       id:
         description: ID der Organisation.
@@ -38,6 +37,7 @@ properties:
   rolle:
     $ref: './components-code-Rolle.yaml'
   loeschung:
+    nullable: true
     description: ''
     type: object
     properties:

--- a/src/openapi/paths-gruppen-id.yaml
+++ b/src/openapi/paths-gruppen-id.yaml
@@ -214,9 +214,7 @@ patch:
     content:
       application/json:
         schema:
-          allOf:
-            - $ref: './components-qs-Gruppe-PUT-request.yaml'
-            - $ref: './components-qs-Gruppe-basis-PATCH-request.yaml'
+          $ref: './components-qs-Gruppe-basis-PATCH-request.yaml'
   responses:
     '200':
       description: OK


### PR DESCRIPTION
Orgid in Gruppen ist jetzt nullable.
(Dazu wurde Gruppe-basis-PATCH um Attribute erweitert, die vorher as Gruppe-PUT imprortiert wurden.)

In Personenkontexten sind bei Löschungen sowohl das Objekt `loeschung` als auch der Wert `zeitpunkt` nullable. (Das kann sich eventuell in noch ändern, wenn wir `nullable` auf Strings beschränken sollten.)

Die Organisation ist in Personenkontexten nicht mehr nullable.