### PR TITLE
#168 die-themen-authentisierung-datenmodell-und-rest-api-deutlicher-t…

### DIFF
--- a/docs/schnittstellen/schnittstellen.md
+++ b/docs/schnittstellen/schnittstellen.md
@@ -57,4 +57,8 @@ Wird kein Content-Type gesetzt, wird automatisch `application/json` angenommen.
 
 > `Accept: application/json`
 
+Die Schulconnex-Schnittstelle trifft keine zwingende Festlegung, welcher Content-Type genutzt wird. Ea bleibt Schulconnex-Servern freigestellt alternativ oder zusätzlich auch Daten im XML-Format anzunehmen oder zu liefern. Is dieses der Fall, so   wird empfohlen, den zu erwartenden Content-Type explizit als `application/xml` anzugeben.
+
+Wird kein Content-Type gesetzt, wird automatisch `application/json` angenommen.
+
 [1]: https://openid.net/specs/openid-connect-core-1_0.html

--- a/docs/schnittstellendefinition/bundling-qs.md
+++ b/docs/schnittstellendefinition/bundling-qs.md
@@ -223,6 +223,10 @@ Es ist dem Betreiber eines Schulconnex-Servers freigestellt, ob ein API-Endpunkt
 
 Ein solcher API-Endpunkt erfordert, anders als HTTP/2 oder HTTP/3 Multiplexing, mehr Aufwand in der Bereitstellung. Er ermöglicht dem Schulconnex-Server jedoch weitere Optimierungen, zusätzlich zur Einsparung beim Verbindungsaufbau, beispielsweise durch die interne Zusammenfassung mehrerer Personenkontexte in einem einzelnen Datenbankaufruf.
 
+## XML-Batching
+
+Analog zum JSON-Batching können Server, welche als Datenrepräsentation XML anbieten, einen entsprechenden API-Endpunkt auch für XML anbieten.
+
 ## Strukturierung mehrerer Anfragen
 
 Weder HTTP Multiplexing noch JSON-Batching erlaubt die direkte Nutzung von Rückgabewerten vorheriger Aufrufe. Daher kann beispielsweise nicht in einem Aufruf ein Personendatensatz und ein dazu gehörender Personenkontext erstellt werden, da die ID des Personendatensatz benötigt wird, um den Personenkontext zu erstellen.

--- a/src/openapi/paths-beziehungen-id.yaml
+++ b/src/openapi/paths-beziehungen-id.yaml
@@ -36,6 +36,11 @@ get:
             allOf:
               - $ref: './components-qs-Beziehung-basis.yaml'
               - $ref: './components-qs-Beziehung.yaml'
+        application/xml:
+          schema:
+            allOf:
+              - $ref: './components-qs-Beziehung-basis.yaml'
+              - $ref: './components-qs-Beziehung.yaml'
     '400':
       description: |
         Bad Request
@@ -88,6 +93,15 @@ delete:
     required: true
     content:
       application/json:
+        schema:
+          type: object
+          required:
+            - revision
+          properties:
+            revision:
+              type: string
+              description: Revision der zugrunde liegenden Beziehung. Dieses Feld ist ein Pflichtfeld.
+      application/xml:
         schema:
           type: object
           required:

--- a/src/openapi/paths-gruppen-id-gruppenzugehoerigkeiten.yaml
+++ b/src/openapi/paths-gruppen-id-gruppenzugehoerigkeiten.yaml
@@ -41,11 +41,17 @@ post:
       application/json:
         schema:
           $ref: './components-qs-Gruppenzugehörigkeit-POST-request.yaml'
+      application/xml:
+        schema:
+          $ref: './components-qs-Gruppenzugehörigkeit-POST-request.yaml'
   responses:
     '201':
       description: OK
       content:
         application/json:
+          schema:
+            $ref: './components-qs-Gruppenzugehörigkeit.yaml'
+        application/xml:
           schema:
             $ref: './components-qs-Gruppenzugehörigkeit.yaml'
     '400':
@@ -139,6 +145,9 @@ get:
       description: OK
       content:
         application/json:
+          schema:
+            $ref: './components-qs-Gruppenzugehörigkeiten.yaml'
+        application/xml:
           schema:
             $ref: './components-qs-Gruppenzugehörigkeiten.yaml'
     '400':

--- a/src/openapi/paths-gruppen-id.yaml
+++ b/src/openapi/paths-gruppen-id.yaml
@@ -29,6 +29,9 @@ get:
         application/json:
           schema:
             $ref: './components-qs-Gruppendatensatz.yaml'
+        application/xml:
+          schema:
+            $ref: './components-qs-Gruppendatensatz.yaml'
     '400':
       description: |
         Bad Request
@@ -115,11 +118,21 @@ put:
           allOf:
             - $ref: './components-qs-Gruppe-PUT-request.yaml'
             - $ref: './components-qs-Gruppe-basis.yaml'
+      application/xml:
+        schema:
+          allOf:
+            - $ref: './components-qs-Gruppe-PUT-request.yaml'
+            - $ref: './components-qs-Gruppe-basis.yaml'
   responses:
     '200':
       description: OK
       content:
         application/json:
+          schema:
+            allOf:
+              - $ref: './components-qs-Gruppe.yaml'
+              - $ref: './components-qs-Gruppe-basis.yaml'
+        application/xml:
           schema:
             allOf:
               - $ref: './components-qs-Gruppe.yaml'
@@ -217,11 +230,21 @@ patch:
           allOf:
             - $ref: './components-qs-Gruppe-PUT-request.yaml'
             - $ref: './components-qs-Gruppe-basis-PATCH-request.yaml'
+      application/xml:
+        schema:
+          allOf:
+            - $ref: './components-qs-Gruppe-PUT-request.yaml'
+            - $ref: './components-qs-Gruppe-basis-PATCH-request.yaml'
   responses:
     '200':
       description: OK
       content:
         application/json:
+          schema:
+            allOf:
+              - $ref: './components-qs-Gruppe.yaml'
+              - $ref: './components-qs-Gruppe-basis.yaml'
+        application/xml:
           schema:
             allOf:
               - $ref: './components-qs-Gruppe.yaml'
@@ -290,6 +313,15 @@ delete:
     required: true
     content:
       application/json:
+        schema:
+          type: object
+          required:
+            - revision
+          properties:
+            revision:
+              type: string
+              description: Revision der zugrunde liegenden Gruppe. Dieses Feld ist ein Pflichtfeld.
+      application/xml:
         schema:
           type: object
           required:

--- a/src/openapi/paths-gruppen.yaml
+++ b/src/openapi/paths-gruppen.yaml
@@ -26,11 +26,19 @@ post:
       application/json:
         schema:
           $ref: './components-qs-Gruppe-basis.yaml'
+      application/xml:
+        schema:
+          $ref: './components-qs-Gruppe-basis.yaml'
   responses:
     '201':
       description: OK
       content:
         application/json:
+          schema:
+            allOf:
+              - $ref: './components-qs-Gruppe.yaml'
+              - $ref: './components-qs-Gruppe-basis.yaml'
+        application/xml:
           schema:
             allOf:
               - $ref: './components-qs-Gruppe.yaml'
@@ -162,6 +170,9 @@ get:
       description: OK
       content:
         application/json:
+          schema:
+            $ref: './components-qs-Gruppendatensätze.yaml'
+        application/xml:
           schema:
             $ref: './components-qs-Gruppendatensätze.yaml'
     '400':

--- a/src/openapi/paths-gruppenzugehoerigkeiten-id.yaml
+++ b/src/openapi/paths-gruppenzugehoerigkeiten-id.yaml
@@ -33,6 +33,9 @@ get:
         application/json:
           schema:
             $ref: './components-qs-Gruppendatensatz.yaml'
+        application/xml:
+          schema:
+            $ref: './components-qs-Gruppendatensatz.yaml'
     '400':
       description: |
         Bad Request
@@ -116,11 +119,17 @@ put:
       application/json:
         schema:
           $ref: './components-qs-Gruppenzugehörigkeit-PUT-request.yaml'
+      application/xml:
+        schema:
+          $ref: './components-qs-Gruppenzugehörigkeit-PUT-request.yaml'
   responses:
     '200':
       description: OK
       content:
         application/json:
+          schema:
+            $ref: './components-qs-Gruppenzugehörigkeit.yaml'
+        application/xml:
           schema:
             $ref: './components-qs-Gruppenzugehörigkeit.yaml'
     '400':
@@ -213,11 +222,17 @@ patch:
       application/json:
         schema:
           $ref: './components-qs-Gruppenzugehörigkeit-PATCH-request.yaml'
+      application/xml:
+        schema:
+          $ref: './components-qs-Gruppenzugehörigkeit-PATCH-request.yaml'
   responses:
     '200':
       description: OK
       content:
         application/json:
+          schema:
+            $ref: './components-qs-Gruppenzugehörigkeit.yaml'
+        application/xml:
           schema:
             $ref: './components-qs-Gruppenzugehörigkeit.yaml'
     '400':
@@ -288,6 +303,15 @@ delete:
     required: true
     content:
       application/json:
+        schema:
+          type: object
+          required:
+            - revision
+          properties:
+            revision:
+              type: string
+              description: Revision der zugrunde liegenden Gruppenzugehörigkeit. Dieses Feld ist ein Pflichtfeld.
+      application/xml:
         schema:
           type: object
           required:

--- a/src/openapi/paths-gruppenzugehoerigkeiten.yaml
+++ b/src/openapi/paths-gruppenzugehoerigkeiten.yaml
@@ -57,6 +57,9 @@ get:
         application/json:
           schema:
             $ref: './components-qs-Gruppendatensätze.yaml'
+        application/xml:
+          schema:
+            $ref: './components-qs-Gruppendatensätze.yaml'
     '400':
       description: |
         Bad Request

--- a/src/openapi/paths-organisation-info.yaml
+++ b/src/openapi/paths-organisation-info.yaml
@@ -26,6 +26,12 @@ get:
               - $ref: './components-Organisation-basis.yaml'
               - $ref: './components-Organisation.yaml'
               - $ref: './components-qs-Organisation.yaml'
+        application/xml:
+          schema:
+            allOf:
+              - $ref: './components-Organisation-basis.yaml'
+              - $ref: './components-Organisation.yaml'
+              - $ref: './components-qs-Organisation.yaml'
     '400':
       description: |
         Bad Request

--- a/src/openapi/paths-organisationen-id-organisationsbeziehungen.yaml
+++ b/src/openapi/paths-organisationen-id-organisationsbeziehungen.yaml
@@ -67,6 +67,9 @@ get:
         application/json:
           schema:
             $ref: './components-qs-Organisationsbeziehungen.yaml'
+        application/xml:
+          schema:
+            $ref: './components-qs-Organisationsbeziehungen.yaml'
     '400':
       description: |
         Bad Request

--- a/src/openapi/paths-organisationen-id.yaml
+++ b/src/openapi/paths-organisationen-id.yaml
@@ -33,6 +33,12 @@ get:
               - $ref: './components-Organisation-basis.yaml'
               - $ref: './components-Organisation.yaml'
               - $ref: './components-qs-Organisation.yaml'
+        application/xml:
+          schema:
+            allOf:
+              - $ref: './components-Organisation-basis.yaml'
+              - $ref: './components-Organisation.yaml'
+              - $ref: './components-qs-Organisation.yaml'
     '400':
       description: |
         Bad Request

--- a/src/openapi/paths-organisationen-info.yaml
+++ b/src/openapi/paths-organisationen-info.yaml
@@ -67,6 +67,9 @@ get:
         application/json:
           schema:
             $ref: './components-dienste-Organisationen-Info.yaml'
+        application/xml:
+          schema:
+            $ref: './components-dienste-Organisationen-Info.yaml'
     '400':
       description: |
         Bad Request

--- a/src/openapi/paths-organisationen.yaml
+++ b/src/openapi/paths-organisationen.yaml
@@ -52,6 +52,9 @@ get:
         application/json:
           schema:
             $ref: './components-qs-Organisationen-GET-request.yaml'
+        application/xml:
+          schema:
+            $ref: './components-qs-Organisationen-GET-request.yaml'
     '400':
       description: |
         Bad Request

--- a/src/openapi/paths-person-info.yaml
+++ b/src/openapi/paths-person-info.yaml
@@ -20,37 +20,6 @@ get:
     Hat sich der Datensatz seit Auslieferung des ETag-Headers nicht geändert, so antwortet
     der Server mit einem Status 304 (Not Modified) und sendet den Datensatz nicht erneut.
 
-    ```json
-    {
-      "pid": <String>, // pseudonymisierte ID
-      "person": <Objekt>, // Objekt vom Typ Person, siehe Datenmodell
-      "personenkontexte": [ // Array mit Objekten
-        {
-          <Objekt>, // Objekt vom Typ Personenkontext, siehe Datenmodell
-          "gruppen": [
-            // Array von Gruppen und Gruppenzugehoerigkeiten eines Personenkontexts
-            "gruppe": ": <Objekt>, // Objekt vom Typ Gruppe
-          ],
-          "beziehungen": {
-            "hat_als_beziehungen": [ // Array von Beziehungen, welche vom Personenkontext ausgehen
-              {
-                "ktid": <Personenkontext-ID welche der Bezug in der angegebenen Rolle ist>
-                "beziehung": <Art der Beziehung>
-              },
-              ...
-            ],
-            "ist_von beziehungen": [
-              {
-                "ktid": <Personenkontext-ID der den Bezug hat >,
-                "beziehung": <Art der Beziehung>
-              }
-            ]
-          }
-        }
-      ]
-    }
-    ```
-
     Die pseudonymisierte ID `pid` in der Rückgabe repräsentiert die `id` im aktuell ausgewählten
     Sicherheitskontext und folgt der gleichen Definition wie die `id`.
 
@@ -88,131 +57,16 @@ get:
     Personenkontext, mit dem eine Beziehung besteht, vorher schon von dem Dienst abgerufen
     wurde und damit dem Dienst bekannt ist.
 
-    ```json
-    {
-      "pid": "df6588cf8dc649ef79fcc852e1064761442a32bf3496ecd9bde0f66a18685aaa",
-      "person": {
-        "stammorganisation": {
-          "id": "fe963bff-e837-4799-91e2-5680222188a5",
-          "kennung": "NI_54321",
-          "name": "Otto Hahn Schule",
-          "anschrift": {
-            "postleitzahl": "29614",
-            "ort": "Soltau",
-            "ortsteil": "Ahlften"
-            "verwaltungspolitischeKodierung: {
-              "bundesland": "03"
-            }
-          },
-          "typ": "Schule"
-        },
-        "name": {
-          "familienname": "Muster",
-          "vorname": "Max"
-        },
-        "geburt": {
-          "datum": "2010-01-01",
-          "volljaehrig": "Ja"
-        },
-        "geschlecht": "m",
-        "lokalisierung": "de",
-        "vertrauensstufe": "Voll"
-      },
-      "personenkontexte": [
-        {
-          "id": "dd29cbf394a218a4637004f5789a210e9ec55b084a648e02a55fa3eb56475e3f",
-          "organisation": {
-            "id": "15685758-d18e-49c1-a644-f9996eb0bf08",
-            "kennung": "NI_12345",
-            "name": "Muster-Schule",
-            "typ": "Schule"
-          },
-          "rolle": "Lern",
-          "erreichbarkeiten": [
-            {
-              "typ": "E-Mail",
-              "kennung": "Max.Muster@Muster-Schule.de"
-            }
-          ],
-          "personenstatus": "Aktiv",
-          "gruppen": [
-            {
-              "gruppe": {
-                "id": "b3201d00-f21f-4986-a39d-02a09c8da26c",
-                "orgid": "9b3f36ad-9d15-49f9-9660-6cf9746ba446",
-                "bezeichnung": "Englisch 6b",
-                "typ": "Kurs",
-                "bereich": "Pflicht",
-                "optionen": [
-                ],
-                "differenzierung": "E",
-                "bildungsziele": [
-                  "RS"
-                ],
-                "jahrgangsstufen": [
-                  "03"
-                ],
-                "faecher": [
-                  {
-                    "kennung": "EN"
-                  },{
-                    "bezeichnung": "Erste Hilfe"
-                  }
-                ],
-                "laufzeit": {
-                  "von": "2026-01-01",
-                  "bis": "2028-12-31"
-                }
-              },
-              "gruppenzugehoerigkeit": [
-                {
-                  "rollen": [
-                    "Lern"
-                  ],
-                  "von": "2026-01-01",
-                  "bis": "2027-12-31"
-                }
-              ],
-              "sonstige_gruppenzugehoerige": [
-                {
-                  "ktid": "7168185a615d8a05a7330e7e5b84288c96783da6f734529760de13335f38016a",
-                  "rollen": [
-                    "Lern",
-                    "GMit"
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ],
-      "beziehungen": {
-        "hat_als_beziehungen": [
-          {
-            "ktid": "1706e0e9cbc89ec256db8552955b981cf9590dffb71c2b586f9f9edae52f980b",
-            "beziehung": "SchB"
-          },
-          {
-            "ktid": "032b0499c3ff360791eb778adad23fa56039b26ad39b3f675e6f6ec6e17f280c",
-            "beziehung": "SchB"
-          }
-        ],
-        "ist_von_beziehungen": [
-          {
-            "ktid": "a91cb0d4fc25a551e909147cfc0e38ebe13462a898c0eda5219762bd96f6782e",
-            "beziehung": "SorgBer"
-          }
-        ]
-      }
-    }
-    ```
   responses:
     '200':
       description: OK
       content:
         application/json:
           schema:
-            $ref: './components-dienste-Personendatensatz.yaml'
+            $ref: './components-qs-Organisationen-GET-request.yaml'
+        application/xml:
+          schema:
+            $ref: './components-qs-Organisationen-GET-request.yaml'
     '304':
       description: Not Modified
     '400':

--- a/src/openapi/paths-personen-id-personenkontexte.yaml
+++ b/src/openapi/paths-personen-id-personenkontexte.yaml
@@ -76,6 +76,11 @@ get:
             type: array
             items:
               $ref: './components-qs-Personenkontext-GET-request.yaml'
+        application/xml:
+          schema:
+            type: array
+            items:
+              $ref: './components-qs-Personenkontext-GET-request.yaml'
     '400':
       description: |
         Bad Request
@@ -159,11 +164,17 @@ post:
       application/json:
         schema:
           $ref: './components-qs-Personenkontext-POST-request.yaml'
+      application/xml:
+        schema:
+          $ref: './components-qs-Personenkontext-POST-request.yaml'
   responses:
     '201':
       description: OK
       content:
         application/json:
+          schema:
+            $ref: './components-qs-Personenkontext.yaml'
+        application/xml:
           schema:
             $ref: './components-qs-Personenkontext.yaml'
     '400':

--- a/src/openapi/paths-personen-id.yaml
+++ b/src/openapi/paths-personen-id.yaml
@@ -31,6 +31,9 @@ get:
         application/json:
           schema:
             $ref: './components-qs-Personendatensatz.yaml'
+        application/xml:
+          schema:
+            $ref: './components-qs-Personendatensatz.yaml'
     '304':
       description: Not Modified
     '400':
@@ -108,11 +111,21 @@ put:
           allOf:
             - $ref: './components-qs-Person-PUT-request.yaml'
             - $ref: './components-qs-Person-basis.yaml'
+      application/xml:
+        schema:
+          allOf:
+            - $ref: './components-qs-Person-PUT-request.yaml'
+            - $ref: './components-qs-Person-basis.yaml'
   responses:
     '200':
       description: OK
       content:
         application/json:
+          schema:
+            allOf:
+              - $ref: './components-qs-Person.yaml'
+              - $ref: './components-qs-Person-basis.yaml'
+        application/xml:
           schema:
             allOf:
               - $ref: './components-qs-Person.yaml'
@@ -208,11 +221,21 @@ patch:
           allOf:
             - $ref: './components-qs-Person-PUT-request.yaml'
             - $ref: './components-qs-Person-basis-PATCH-request.yaml'
+      application/xml:
+        schema:
+          allOf:
+            - $ref: './components-qs-Person-PUT-request.yaml'
+            - $ref: './components-qs-Person-basis-PATCH-request.yaml'
   responses:
     '200':
       description: OK
       content:
         application/json:
+          schema:
+            allOf:
+              - $ref: './components-qs-Person.yaml'
+              - $ref: './components-qs-Person-basis.yaml'
+        application/xml:
           schema:
             allOf:
               - $ref: './components-qs-Person.yaml'
@@ -283,6 +306,15 @@ delete:
     required: true
     content:
       application/json:
+        schema:
+          type: object
+          required:
+            - revision
+          properties:
+            revision:
+              type: string
+              description: Revision der Person des zugrunde liegenden Personendatensatzes. Dieses Feld ist ein Pflichtfeld.
+      application/xml:
         schema:
           type: object
           required:

--- a/src/openapi/paths-personen-info.yaml
+++ b/src/openapi/paths-personen-info.yaml
@@ -117,6 +117,9 @@ get:
         application/json:
           schema:
             $ref: './components-dienste-Personendatensätze.yaml'
+        application/xml:
+          schema:
+            $ref: './components-dienste-Personendatensätze.yaml'
     '304':
       description: Not Modified
     '400':

--- a/src/openapi/paths-personen.yaml
+++ b/src/openapi/paths-personen.yaml
@@ -79,6 +79,9 @@ get:
         application/json:
           schema:
             $ref: './components-Personen-GET-request.yaml'
+        application/xml:
+          schema:
+            $ref: './components-Personen-GET-request.yaml'
     '400':
       description: |
         Bad Request
@@ -179,11 +182,19 @@ post:
       application/json:
         schema:
           $ref: './components-qs-Person-basis.yaml'
+      application/xml:
+        schema:
+          $ref: './components-qs-Person-basis.yaml'
   responses:
     '201':
       description: OK
       content:
         application/json:
+          schema:
+            allOf:
+              - $ref: './components-qs-Person.yaml'
+              - $ref: './components-qs-Person-basis.yaml'
+        application/xml:
           schema:
             allOf:
               - $ref: './components-qs-Person.yaml'

--- a/src/openapi/paths-personenkontexte-id-beziehungen.yaml
+++ b/src/openapi/paths-personenkontexte-id-beziehungen.yaml
@@ -57,11 +57,17 @@ post:
       application/json:
         schema:
           $ref: './components-qs-Beziehung-POST-request.yaml'
+      application/xml:
+        schema:
+          $ref: './components-qs-Beziehung-POST-request.yaml'
   responses:
     '201':
       description: OK
       content:
         application/json:
+          schema:
+            $ref: './components-qs-Beziehung-basis.yaml'
+        application/xml:
           schema:
             $ref: './components-qs-Beziehung-basis.yaml'
     '400':
@@ -165,6 +171,9 @@ get:
       description: OK
       content:
         application/json:
+          schema:
+            $ref: './components-qs-Beziehungen.yaml'
+        application/xml:
           schema:
             $ref: './components-qs-Beziehungen.yaml'
     '400':

--- a/src/openapi/paths-personenkontexte-id-sichtfreigaben.yaml
+++ b/src/openapi/paths-personenkontexte-id-sichtfreigaben.yaml
@@ -45,11 +45,19 @@ post:
       application/json:
         schema:
           $ref: './components-Sichtfreigabe-basis.yaml'
+      application/xml:
+        schema:
+          $ref: './components-Sichtfreigabe-basis.yaml'
   responses:
     '200':
       description: OK
       content:
         application/json:
+          schema:
+            allOf:
+              - $ref: './components-Sichtfreigabe.yaml'
+              - $ref: './components-Sichtfreigabe-basis.yaml'
+        application/xml:
           schema:
             allOf:
               - $ref: './components-Sichtfreigabe.yaml'
@@ -116,6 +124,9 @@ get:
       description: OK
       content:
         application/json:
+          schema:
+            $ref: './components-qs-Sichtfreigaben.yaml'
+        application/xml:
           schema:
             $ref: './components-qs-Sichtfreigaben.yaml'
     '400':

--- a/src/openapi/paths-personenkontexte-id.yaml
+++ b/src/openapi/paths-personenkontexte-id.yaml
@@ -33,6 +33,9 @@ get:
         application/json:
           schema:
             $ref: './components-qs-Personendatensatz.yaml'
+        application/xml:
+          schema:
+            $ref: './components-qs-Personendatensatz.yaml'
     '304':
       description: Not Modified
     '400':
@@ -124,11 +127,17 @@ put:
       application/json:
         schema:
           $ref: './components-qs-Personenkontext-PUT-request.yaml'
+      application/xml:
+        schema:
+          $ref: './components-qs-Personenkontext-PUT-request.yaml'
   responses:
     '200':
       description: OK
       content:
         application/json:
+          schema:
+            $ref: './components-qs-Personenkontext.yaml'
+        application/xml:
           schema:
             $ref: './components-qs-Personenkontext.yaml'
     '400':
@@ -232,11 +241,17 @@ patch:
       application/json:
         schema:
           $ref: './components-qs-Personenkontext-PATCH-request.yaml'
+      application/xml:
+        schema:
+          $ref: './components-qs-Personenkontext-PATCH-request.yaml'
   responses:
     '200':
       description: OK
       content:
         application/json:
+          schema:
+            $ref: './components-qs-Personenkontext.yaml'
+        application/xml:
           schema:
             $ref: './components-qs-Personenkontext.yaml'
     '400':
@@ -307,6 +322,15 @@ delete:
     required: true
     content:
       application/json:
+        schema:
+          type: object
+          required:
+            - revision
+          properties:
+            revision:
+              type: string
+              description: Revision der Person des zugrunde liegenden Personenkontext. Dieses Feld ist ein Pflichtfeld.
+      application/xml:
         schema:
           type: object
           required:

--- a/src/openapi/paths-personenkontexte.yaml
+++ b/src/openapi/paths-personenkontexte.yaml
@@ -101,6 +101,26 @@ get:
                   type: array
                   items:
                     $ref: './components-qs-Personenkontext-GET-request.yaml'
+        application/xml:
+          schema:
+            type: array
+            items:
+              type: object
+              properties:
+                person:
+                  type: object
+                  required:
+                    - id
+                  properties:
+                    id:
+                      description: ID der Person. Wird vom Schulconnex-Server vergeben und ist eindeutig. Dieses Attribut ist unveränderbar (immutable).
+                      type: string
+                      readOnly: true
+                      example: a6e1a860-8d44-4b2b-aef7-aa2c8bf5beb5
+                personenkontexte:
+                  type: array
+                  items:
+                    $ref: './components-qs-Personenkontext-GET-request.yaml'
     '400':
       description: |
         Bad Request

--- a/src/openapi/paths-sichtfreigaben-id.yaml
+++ b/src/openapi/paths-sichtfreigaben-id.yaml
@@ -46,6 +46,15 @@ delete:
             revision:
               type: string
               description: Revision der zugrunde liegenden Sichtfreigabe. Dieses Feld ist ein Pflichtfeld.
+      application/xml:
+        schema:
+          type: object
+          required:
+            - revision
+          properties:
+            revision:
+              type: string
+              description: Revision der zugrunde liegenden Sichtfreigabe. Dieses Feld ist ein Pflichtfeld.
   responses:
     '204':
       description: |


### PR DESCRIPTION
…rennen-tfs-5371

Bei allen OpenAPI-Beschreibungen zu `application/json` auch `application/xml` hinzugefügt, im Request- und Response-Beispiele auch in XML anzeigen zu können.

Explizite JSON Beispiele aus der /get-person Beschreibung herausgenommen.

Bei der Beschreibung der REST-API darauf hingewiesen, das JSON zwar üblich ist, aber nicht durch die Spezifikation vorgeschrieben ist.

Parallel zu JSON-Batching auch XML-Batching erwähnt.